### PR TITLE
Fix lookup of included constants during linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.2.1 (unreleased)
 ------------------
 
+- #7: Fix lookup of included constants during linking
 - #4: Add automatic Parcelable implementation
 - #2: Fix nested-generic fields with default values
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
@@ -347,15 +347,19 @@ class Linker {
     @Nullable
     Named lookupSymbol(String symbol) {
         Named named = program.symbols().get(symbol);
-        if (named == null && symbol.indexOf('.') != -1) {
-            // 'symbol' may be a qualified name for an included type
-            ThriftType type = typesByName.get(symbol);
-            if (type != null) {
-                String name = type.name();
+        if (named == null) {
+            // Symbol may be a qualified name
+            int ix = symbol.indexOf('.');
+            if (ix != -1) {
+                String includeName = symbol.substring(0, ix);
+                String qualifiedName = symbol.substring(ix + 1);
+                String expectedPath = includeName + ".thrift";
                 for (Program includedProgram : program.includes()) {
-                    named = includedProgram.symbols().get(name);
-                    if (named != null) {
-                        break;
+                    if (includedProgram.location().path().equals(expectedPath)) {
+                        named = includedProgram.symbols().get(qualifiedName);
+                        if (named != null) {
+                            break;
+                        }
                     }
                 }
             }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -208,7 +208,8 @@ public final class Program {
                 .append(unions)
                 .append(exceptions)
                 .append(services)
-                .append(typedefs);
+                .append(typedefs)
+                .append(constants);
     }
 
     /**

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -184,6 +184,31 @@ public class LoaderTest {
     }
 
     @Test
+    public void includedConstants() throws Exception {
+        File producer = tempDir.newFile("p.thrift");
+        File consumer = tempDir.newFile("c.thrift");
+
+        String producerThrift = "" +
+                "const i32 foo = 10";
+
+        String consumerThrift = "" +
+                "include 'p.thrift'\n" +
+                "\n" +
+                "struct Bar {\n" +
+                "  1: required i32 field = p.foo\n" +
+                "}\n";
+
+        writeTo(producer, producerThrift);
+        writeTo(consumer, consumerThrift);
+
+        Loader loader = new Loader();
+        loader.addThriftFile(producer.getAbsolutePath());
+        loader.addThriftFile(consumer.getAbsolutePath());
+
+        loader.load();
+    }
+
+    @Test
     public void crazyIncludes() throws Exception {
         File f1 = tempDir.newFile("a.thrift");
         File f2 = tempDir.newFile("b.thrift");


### PR DESCRIPTION
`Constant` is a `Named`, but was accidentally omitted from `Program.symbols()`.  `Linker#lookupSymbol(String)`, even though it returns a `Named`, internally assumed that only types could be included.

Both bugs are resolved here.

Fixes #7 