### PR TITLE
Add 'ErrorReporter'

### DIFF
--- a/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
+++ b/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
@@ -23,6 +23,7 @@ package com.microsoft.thrifty.compiler;
 import com.microsoft.thrifty.compiler.spi.TypeProcessor;
 import com.microsoft.thrifty.gen.ThriftyCodeGenerator;
 import com.microsoft.thrifty.schema.FieldNamingPolicy;
+import com.microsoft.thrifty.schema.LoadFailedException;
 import com.microsoft.thrifty.schema.Loader;
 import com.microsoft.thrifty.schema.Schema;
 
@@ -179,7 +180,17 @@ public class ThriftyCompiler {
             loader.addIncludePath(new File(dir));
         }
 
-        Schema schema = loader.load();
+        Schema schema;
+        try {
+            schema = loader.load();
+        } catch (LoadFailedException e) {
+            for (String report : e.errorReporter().formattedReports()) {
+                System.out.println(report);
+            }
+
+            Runtime.getRuntime().exit(1);
+            return;
+        }
 
         ThriftyCodeGenerator gen = new ThriftyCodeGenerator(schema);
         if (listTypeName != null) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -69,7 +69,7 @@ public class Constant extends Named {
         try {
             validate(linker, value, type);
         } catch (IllegalStateException e) {
-            linker.addError(e.getMessage());
+            linker.addError(location(), e.getMessage());
         }
     }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ErrorReporter.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ErrorReporter.java
@@ -1,0 +1,68 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ErrorReporter {
+    private boolean hasError = false;
+    private List<Report> reports = new ArrayList<>();
+
+    public void warn(Location location, String message) {
+        reports.add(Report.create(Level.WARNING, location, message));
+    }
+
+    public void error(Location location, String message) {
+        hasError = true;
+        reports.add(Report.create(Level.ERROR, location, message));
+    }
+
+    boolean hasError() {
+        return hasError;
+    }
+
+    public ImmutableList<Report> reports() {
+        return ImmutableList.copyOf(reports);
+    }
+
+    public ImmutableList<String> formattedReports() {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        StringBuilder sb = new StringBuilder();
+        for (Report report : reports) {
+            switch (report.level()) {
+                case WARNING: sb.append("W: "); break;
+                case ERROR:   sb.append("E: "); break;
+                default:
+                    throw new AssertionError("Unexpected report level: " + report.level());
+            }
+
+            sb.append(report.message());
+            sb.append(" (at ");
+            sb.append(report.location());
+            sb.append(")");
+
+            builder.add(sb.toString());
+
+            sb.setLength(0);
+        }
+        return builder.build();
+    }
+
+    @AutoValue
+    abstract static class Report {
+        public abstract Level level();
+        public abstract Location location();
+        public abstract String message();
+
+        static Report create(Level level, Location location, String message) {
+            return new AutoValue_ErrorReporter_Report(level, location, message);
+        }
+    }
+
+    public enum Level {
+        WARNING,
+        ERROR
+    }
+}

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -47,6 +47,10 @@ public final class Field {
         this.annotations = annotationBuilder.build();
     }
 
+    public Location location() {
+        return element.location();
+    }
+
     public int id() {
         Integer id = element.fieldId();
         if (id == null) {
@@ -116,7 +120,11 @@ public final class Field {
     void validate(Linker linker) {
         ConstValueElement value = element.constValue();
         if (value != null) {
-            Constant.validate(linker, value, type);
+            try {
+                Constant.validate(linker, value, type);
+            } catch (IllegalStateException e) {
+                linker.addError(value.location(), e.getMessage());
+            }
         }
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/LoadFailedException.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/LoadFailedException.java
@@ -1,0 +1,14 @@
+package com.microsoft.thrifty.schema;
+
+public class LoadFailedException extends Exception {
+    private final ErrorReporter errorReporter;
+
+    public LoadFailedException(Throwable cause, ErrorReporter errorReporter) {
+        super(cause);
+        this.errorReporter = errorReporter;
+    }
+
+    public ErrorReporter errorReporter() {
+        return errorReporter;
+    }
+}

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -221,6 +221,7 @@ public final class Program {
     void loadIncludedPrograms(Loader loader, Set<Program> visited) throws IOException {
         if (!visited.add(this)) {
             if (includedPrograms == null) {
+                loader.errorReporter().error(location(), "Circular include; file includes itself transitively");
                 throw new IllegalStateException("Circular include: " + location().path()
                         + " includes itself transitively");
             }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -108,13 +108,13 @@ public class StructType extends Named {
         for (Field field : fields) {
             Field dupe = fieldsById.put(field.id(), field);
             if (dupe != null) {
-                linker.addError(
+                linker.addError(dupe.location(),
                         "Duplicate field IDs: " + field.name() + " and " + dupe.name()
                         + " both have the same ID (" + field.id() + ")");
             }
 
             if (isUnion() && field.required()) {
-                linker.addError("Unions may not have required fields: " + field.name());
+                linker.addError(field.location(), "Unions may not have required fields: " + field.name());
             }
         }
     }

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -179,8 +179,8 @@ public class LoaderTest {
         try {
             loader.load();
             fail();
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), containsString("Failed to resolve type TestEnum"));
+        } catch (LoadFailedException e) {
+            assertHasError(e, "Failed to resolve type 'TestEnum'");
         }
     }
 
@@ -265,8 +265,8 @@ public class LoaderTest {
                     .addThriftFile(f3.getAbsolutePath())
                     .load();
             fail("Circular includes should fail to load");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("Circular include"));
+        } catch (LoadFailedException e) {
+            assertHasError(e, "Circular include");
         }
     }
 
@@ -285,7 +285,8 @@ public class LoaderTest {
         try {
             loader.load();
             fail("Circular typedefs should fail to link");
-        } catch (RuntimeException ignored) {
+        } catch (LoadFailedException e) {
+            assertHasError(e, "Unresolvable typedef");
         }
     }
 
@@ -368,8 +369,8 @@ public class LoaderTest {
         try {
             loader.load();
             fail();
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), containsString("Failed to resolve type Undefined"));
+        } catch (LoadFailedException e) {
+            assertHasError(e, "Failed to resolve type 'Undefined'");
         }
     }
 
@@ -419,5 +420,14 @@ public class LoaderTest {
         sink.writeUtf8(content);
         sink.flush();
         sink.close();
+    }
+
+    private static void assertHasError(LoadFailedException exception, String expectedMessage) {
+        for (ErrorReporter.Report report : exception.errorReporter().reports()) {
+            if (report.message().contains(expectedMessage)) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected a reported error containing '" + expectedMessage + "'");
     }
 }


### PR DESCRIPTION
To implement compiler warnings, we need a consistent way of reporting
warnings.  It behooves us to simplify things and report errors in the
same way.  Some places in code, we have been throwing exceptions, while
in other places we've been reporting errors via LinkEnvironment.

We still keep such exceptions for flow control, but at least now we do
not conflate flow control with error reporting.

Fixes #11.