### PR TITLE
Relax the `@redacted` regexp

### DIFF
--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
@@ -726,7 +726,7 @@ public final class ThriftyCodeGenerator {
     }
 
     private static final Pattern REDACTED_PATTERN = Pattern.compile(
-            "\\W@redacted\\W", Pattern.CASE_INSENSITIVE);
+            "@redacted", Pattern.CASE_INSENSITIVE);
 
     /**
      * Builds a #toString() method for the given struct.


### PR DESCRIPTION
Fixes the case where the only documentation a member has is `@redacted`, which currently does not match.