### PR TITLE
Thrifty compiler bugs

### DIFF
--- a/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
+++ b/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
@@ -20,6 +20,7 @@
  */
 package com.microsoft.thrifty.compiler;
 
+import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.compiler.spi.TypeProcessor;
 import com.microsoft.thrifty.gen.ThriftyCodeGenerator;
 import com.microsoft.thrifty.schema.FieldNamingPolicy;
@@ -184,8 +185,14 @@ public class ThriftyCompiler {
         try {
             schema = loader.load();
         } catch (LoadFailedException e) {
-            for (String report : e.errorReporter().formattedReports()) {
-                System.out.println(report);
+            ImmutableList<String> errors = e.errorReporter().formattedReports();
+            // Without this, some errors don't get printed out and the program just exits with error 1
+            if (errors.isEmpty()) {
+                System.out.println(e.toString());
+            } else {
+                for (String report : errors) {
+                    System.out.println(report);
+                }
             }
 
             Runtime.getRuntime().exit(1);

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -258,6 +258,12 @@ public class Constant extends Named {
                 } else {
                     throw new IllegalStateException("bad enum literal: " + value.value());
                 }
+            } else if (named instanceof Typedef) {
+                Typedef td = (Typedef) named;
+                if (td.oldType().isEnum()) {
+                    return;
+                }
+                throw new IllegalStateException("Invalid type");
             } else if (named instanceof Constant) {
                 if (!named.type().getTrueType().equals(expected)) {
                     throw new IllegalStateException("Invalid type");

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -289,7 +289,7 @@ public final class Program {
             symbolMap.put(enumName.name(), enumName);
         }
     }
-    
+
     private IllegalStateException duplicateSymbol(String symbol, Named oldValue, Named newValue) {
         throw new IllegalStateException(
                 "Duplicate symbols: '" + symbol + "' defined at "


### PR DESCRIPTION
Fix a few thrifty compiler bugs:
1. Allow different ThriftTypes with the same name to work. This is valid in Java so should be allowed.
2. Fix issue with TypeDef enums where the compiler failed to recognize the value as a valid enum
