### PR TITLE
Emit const references in codegen where appropriate.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Location.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Location.java
@@ -60,6 +60,23 @@ public final class Location {
         return column;
     }
 
+    /**
+     * Computes and returns the Thrift 'program' name, which is the filename portion
+     * of the full path *without* the .thrift extension.
+     */
+    public String getProgramName() {
+        String name = path;
+        int separatorIndex = name.lastIndexOf(File.pathSeparatorChar);
+        if (separatorIndex != -1) {
+            name = name.substring(separatorIndex + 1);
+        }
+        int dotIndex = name.indexOf('.');
+        if (dotIndex != -1) {
+            name = name.substring(0, dotIndex);
+        }
+        return name;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(base.length() + path.length());

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstValueElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstValueElement.java
@@ -43,6 +43,30 @@ public abstract class ConstValueElement {
     public abstract Kind kind();
     public abstract Object value();
 
+    public boolean isInt() {
+        return kind() == Kind.INTEGER;
+    }
+
+    public boolean isDouble() {
+        return kind() == Kind.DOUBLE;
+    }
+
+    public boolean isString() {
+        return kind() == Kind.STRING;
+    }
+
+    public boolean isIdentifier() {
+        return kind() == Kind.IDENTIFIER;
+    }
+
+    public boolean isList() {
+        return kind() == Kind.LIST;
+    }
+
+    public boolean isMap() {
+        return kind() == Kind.MAP;
+    }
+
     public String getAsString() {
         if (kind() == Kind.STRING || kind() == Kind.IDENTIFIER) {
             return (String) value();


### PR DESCRIPTION
ConstantBuilder wasn't aware of refernces to other consts when
rendering; this would result in anything from a compiler crash to
incorrect values being emitted.  This is fixed here.

This is definitely more duct-tape than architecture; I punted on a good
solution for ensuring that qualified names are correctly resolved.  We
should think about how to represent this kind of scoping in the final
linked Schema - that, or teach fields to be aware of this sort of
indirection and validate properly during linking.

Fixes #35.