### PR TITLE
Add type-element annotations to Typedef

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ allprojects {
                 testing: [
                         'junit:junit:4.12',
                         'org.mockito:mockito-core:1.10.19',
-                        'com.google.truth:truth:0.28'
+                        'com.google.truth:truth:0.28',
+                        'org.hamcrest:hamcrest-all:1.3'
                 ]
         ]
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public final class Typedef extends Named {
     private final TypedefElement element;
     private final ImmutableMap<String, String> annotations;
+    private final ImmutableMap<String, String> sourceTypeAnnotations;
     private ThriftType oldType;
     private ThriftType type;
 
@@ -42,6 +43,13 @@ public final class Typedef extends Named {
             annotationBuilder.putAll(anno.values());
         }
         this.annotations = annotationBuilder.build();
+
+        ImmutableMap.Builder<String, String> sourceTypeAnnotationBuilder = ImmutableMap.builder();
+        AnnotationElement sourceAnno = element.oldType().annotations();
+        if (sourceAnno != null) {
+            sourceTypeAnnotationBuilder.putAll(sourceAnno.values());
+        }
+        this.sourceTypeAnnotations = sourceTypeAnnotationBuilder.build();
     }
 
     @Override
@@ -69,6 +77,10 @@ public final class Typedef extends Named {
 
     public ImmutableMap<String, String> annotations() {
         return annotations;
+    }
+
+    public ImmutableMap<String, String> sourceTypeAnnotations() {
+        return sourceTypeAnnotations;
     }
 
     boolean link(Linker linker) {

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -31,8 +31,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -413,6 +413,24 @@ public class LoaderTest {
         loader.addThriftFile(f2.getAbsolutePath());
 
         loader.load();
+    }
+
+    @Test
+    public void typedefsWithAnnotations() throws Exception {
+        File f = tempDir.newFile("typedef.thrift");
+
+        String thrift = "namespace java typedef.annotations\n" +
+                "\n" +
+                "typedef i64 (js.type = \"Date\") Date";
+
+        writeTo(f, thrift);
+
+        Loader loader = new Loader();
+        loader.addThriftFile(f.getAbsolutePath());
+        Schema schema = loader.load();
+
+        Typedef td = schema.typedefs().get(0);
+        assertThat(td.sourceTypeAnnotations(), hasEntry("js.type", "Date"));
     }
 
     private static void writeTo(File file, String content) throws IOException {


### PR DESCRIPTION
Generally we do not handle handle annotations on typenames very well; this trials a way to do better.

Fixes #41.