### PR TITLE
Preserve annotations on type references

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
@@ -302,7 +302,7 @@ class Linker {
         if (tt != null) {
             // If we are resolving e.g. the type of a field element, the type
             // may carry annotations that are not part of the canonical type.
-            if (annotations.isEmpty()) {
+            if (!annotations.isEmpty()) {
                 return tt.withAnnotations(annotations);
             } else {
                 return tt;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public final class Typedef extends Named {
     private final TypedefElement element;
     private final ImmutableMap<String, String> annotations;
-    private final ImmutableMap<String, String> sourceTypeAnnotations;
     private ThriftType oldType;
     private ThriftType type;
 
@@ -43,13 +42,6 @@ public final class Typedef extends Named {
             annotationBuilder.putAll(anno.values());
         }
         this.annotations = annotationBuilder.build();
-
-        ImmutableMap.Builder<String, String> sourceTypeAnnotationBuilder = ImmutableMap.builder();
-        AnnotationElement sourceAnno = element.oldType().annotations();
-        if (sourceAnno != null) {
-            sourceTypeAnnotationBuilder.putAll(sourceAnno.values());
-        }
-        this.sourceTypeAnnotations = sourceTypeAnnotationBuilder.build();
     }
 
     @Override
@@ -80,7 +72,7 @@ public final class Typedef extends Named {
     }
 
     public ImmutableMap<String, String> sourceTypeAnnotations() {
-        return sourceTypeAnnotations;
+        return oldType.annotations();
     }
 
     boolean link(Linker linker) {

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -104,7 +105,7 @@ public class LoaderTest {
         Field param = method.paramTypes().get(0);
         assertThat(param.name(), is("arg1"));
         assertThat(param.type().name(), is("S"));
-        assertThat(param.type() == st.type(), is(true));
+        assertThat(param.type(), equalTo(st.type()));
     }
 
     @Test
@@ -145,7 +146,7 @@ public class LoaderTest {
         assertThat(et.type().name(), is("TestEnum"));
 
         Typedef td = schema.typedefs().get(0);
-        assertThat(td.oldType(), sameInstance(et.type()));
+        assertThat(td.oldType(), equalTo(et.type()));
     }
 
     @Test
@@ -321,8 +322,8 @@ public class LoaderTest {
         assertThat(map.oldType().isMap(), is(true));
 
         ThriftType.MapType mt = (ThriftType.MapType) map.oldType();
-        assertThat(mt.keyType(), sameInstance(code.type()));
-        assertThat(mt.valueType(), sameInstance(msg.type()));
+        assertThat(mt.keyType(), equalTo(code.type()));
+        assertThat(mt.valueType(), equalTo(msg.type()));
     }
 
     @Test

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ThriftTypeTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ThriftTypeTest.java
@@ -22,10 +22,14 @@ package com.microsoft.thrifty.schema;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ThriftTypeTest {
     @Test
@@ -115,5 +119,41 @@ public class ThriftTypeTest {
 
         assertThat(ThriftType.I8.isBuiltin(), is(true));
         assertThat(ctr.get(), is(2));
+    }
+
+    @Test
+    public void typesWithSameNameAreEqual() {
+        ThriftType one = ThriftType.get("foo", null);
+        ThriftType two = ThriftType.get("foo", null);
+
+        assertThat(one, equalTo(two));
+    }
+
+    @Test
+    public void annotationsDoNotAffectEquality() {
+        ThriftType one = ThriftType.get("foo", null, Collections.singletonMap("test", "one"));
+        ThriftType two = ThriftType.get("foo", null, Collections.singletonMap("test", "two"));
+
+        assertThat(one, equalTo(two));
+    }
+
+    @Test
+    public void withAnnotationsMergesAnnotations() {
+        ThriftType one = ThriftType.get("foo", null, Collections.singletonMap("foo", "bar"));
+        ThriftType two = one.withAnnotations(Collections.singletonMap("baz", "quux"));
+
+        assertThat(two.annotations(), hasEntry("foo", "bar"));
+        assertThat(two.annotations(), hasEntry("baz", "quux"));
+    }
+
+    @Test
+    public void typeAnnotationsAreImmutable() {
+        ThriftType one = ThriftType.get("foo", null, Collections.singletonMap("foo", "bar"));
+        try {
+            one.annotations().put("baz", "quux");
+            fail("Expected ThriftType#annotations() to be immutable!");
+        } catch (UnsupportedOperationException ignored) {
+            // pass
+        }
     }
 }


### PR DESCRIPTION
This allows arbitrary type-references (that is, type names that are part of definitions of other types) to keep retain thrift annotations after linking.

Prior to this change, we canonicalized ThriftTypes into single instances, and a byproduct of that process was the elimination of these annotations.  Now we can keep them and use them in codegen.

This is a better solution to #43.