### PR TITLE
Print "null" for missing obfuscated fields

### DIFF
--- a/thrifty-integration-tests/ClientThriftTest.thrift
+++ b/thrifty-integration-tests/ClientThriftTest.thrift
@@ -411,3 +411,7 @@ struct ObfuscatedCollections {
   1: required list<i32> numz = [1, 2, 3] (obfuscated)
   2: required map<string, string> stringz = {} (obfuscated)
 }
+
+struct HasObfuscation {
+  1: optional string ssn (obfuscated = "true")
+}

--- a/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/RedactionTest.java
+++ b/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/RedactionTest.java
@@ -1,6 +1,7 @@
 package com.microsoft.thrifty.integration;
 
 import com.microsoft.thrifty.integration.gen.HasCommentBasedRedaction;
+import com.microsoft.thrifty.integration.gen.HasObfuscation;
 import com.microsoft.thrifty.integration.gen.HasRedaction;
 import com.microsoft.thrifty.integration.gen.ObfuscatedCollections;
 import org.junit.Test;
@@ -64,5 +65,14 @@ public class RedactionTest {
                 .build();
 
         assertThat(oc.toString(), containsString("stringz=map<string, string>(size=1)"));
+    }
+
+    @Test
+    public void obfuscatedString() {
+        HasObfuscation ho = new HasObfuscation.Builder().build();
+        assertThat(ho.toString(), is("HasObfuscation{ssn=null}"));
+
+        ho = new HasObfuscation.Builder().ssn("123-45-6789").build();
+        assertThat(ho.toString(), is("HasObfuscation{ssn=1E1DB4B3}"));
     }
 }

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/util/ObfuscationUtil.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/util/ObfuscationUtil.java
@@ -49,10 +49,11 @@ public final class ObfuscationUtil {
     }
 
     public static String hash(Object value) {
-        int hashcode = 0x9e3779b9;
-        if (value != null) {
-            hashcode = value.hashCode();
+        if (value == null) {
+            return "null";
         }
+
+        int hashcode = value.hashCode();
 
         // Integer.toHexString(int) doesn't pad to 8 chars;
         // this is simple enough to do ourselves.

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/util/ObfuscationUtilTest.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/util/ObfuscationUtilTest.java
@@ -60,4 +60,16 @@ public class ObfuscationUtilTest {
         Map<String, Integer> map = Collections.emptyMap();
         assertThat(ObfuscationUtil.summarizeMap(map, "string", "i32"), is("map<string, i32>(size=0)"));
     }
+
+    @Test
+    public void summarizeSingleObject() {
+        Integer obj = 0x12345678;
+        assertThat(ObfuscationUtil.hash(obj), is("12345678"));
+    }
+
+    @Test
+    public void summarizeNullObjext() {
+        String obj = null;
+        assertThat(ObfuscationUtil.hash(obj), is("null"));
+    }
 }


### PR DESCRIPTION
This is a behavior change; previously, a constant hex value would be
printed.  It's not much different from before, privacy-wise, in that
missing values are still indicated; it will, however, be much easier to
debug thrifts visually.

Fixes #57.