### PR TITLE
Allow constants and types with same name

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
@@ -480,6 +480,30 @@ class Linker {
         return named;
     }
 
+    @Nullable
+    Constant lookupConst(String symbol) {
+        Constant constant = program.constantMap().get(symbol);
+        if (constant == null) {
+            // As above, 'symbol' may be a reference to an included
+            // constant.
+            int ix = symbol.indexOf('.');
+            if (ix != -1) {
+                String includeName = symbol.substring(0, ix);
+                String qualifiedName = symbol.substring(ix + 1);
+                String expectedPath = includeName + ".thrift";
+                for (Program includedProgram : program.includes()) {
+                    if (includedProgram.location().path().equals(expectedPath)) {
+                        constant = includedProgram.constantMap().get(qualifiedName);
+                        if (constant != null) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return constant;
+    }
+
     void addError(Location location, String error) {
         reporter.error(location, error);
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -201,9 +201,12 @@ public final class Program {
     }
 
     /**
-     * Get all named elements declared in this Program.
+     * Get all named types declared in this Program.
+     *
+     * Note that this does not include {@link #constants()}, which are
+     * not types.
      */
-    public Iterable<Named> names() {
+    public Iterable<Named> allTypeNames() {
         // Some type-resolution subtlety eludes me.  I'd have thought that
         // Iterable<EnumType> is castable to Iterable<Named> (inheritance),
         // but the IDE claims otherwise.  So, instead of FluentIterable.<Named>from(enums),
@@ -215,8 +218,7 @@ public final class Program {
                 .append(unions)
                 .append(exceptions)
                 .append(services)
-                .append(typedefs)
-                .append(constants);
+                .append(typedefs);
     }
 
     /**
@@ -246,11 +248,7 @@ public final class Program {
         this.includedPrograms = includes.build();
 
         LinkedHashMap<String, Named> symbolMap = new LinkedHashMap<>();
-        for (Named named : names()) {
-            if (named instanceof Constant) {
-                continue;
-            }
-
+        for (Named named : allTypeNames()) {
             Named oldValue = symbolMap.put(named.name(), named);
             if (oldValue != null) {
                 throw duplicateSymbol(named.name(), oldValue, named);
@@ -260,14 +258,10 @@ public final class Program {
         this.symbols = ImmutableMap.copyOf(symbolMap);
 
         LinkedHashMap<String, Constant> constSymbolMap = new LinkedHashMap<>();
-        for (Named named : names()) {
-            if (!(named instanceof Constant)) {
-                continue;
-            }
-
-            Constant oldValue = constSymbolMap.put(named.name(), (Constant) named);
+        for (Constant constant : constants()) {
+            Constant oldValue = constSymbolMap.put(constant.name(), constant);
             if (oldValue != null) {
-                throw duplicateSymbol(named.name(), oldValue, named);
+                throw duplicateSymbol(constant.name(), oldValue, constant);
             }
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -57,6 +57,7 @@ public final class Program {
 
     private ImmutableList<Program> includedPrograms;
     private ImmutableMap<String, Named> symbols;
+    private ImmutableMap<String, Constant> constSymbols;
 
     Program(ThriftFileElement element, FieldNamingPolicy fieldNamingPolicy) {
         this.element = element;
@@ -195,6 +196,10 @@ public final class Program {
         return this.symbols;
     }
 
+    public ImmutableMap<String, Constant> constantMap() {
+        return this.constSymbols;
+    }
+
     /**
      * Get all named elements declared in this Program.
      */
@@ -242,6 +247,10 @@ public final class Program {
 
         LinkedHashMap<String, Named> symbolMap = new LinkedHashMap<>();
         for (Named named : names()) {
+            if (named instanceof Constant) {
+                continue;
+            }
+
             Named oldValue = symbolMap.put(named.name(), named);
             if (oldValue != null) {
                 throw duplicateSymbol(named.name(), oldValue, named);
@@ -249,6 +258,20 @@ public final class Program {
         }
 
         this.symbols = ImmutableMap.copyOf(symbolMap);
+
+        LinkedHashMap<String, Constant> constSymbolMap = new LinkedHashMap<>();
+        for (Named named : names()) {
+            if (!(named instanceof Constant)) {
+                continue;
+            }
+
+            Constant oldValue = constSymbolMap.put(named.name(), (Constant) named);
+            if (oldValue != null) {
+                throw duplicateSymbol(named.name(), oldValue, named);
+            }
+        }
+
+        this.constSymbols = ImmutableMap.copyOf(constSymbolMap);
     }
 
     private IllegalStateException duplicateSymbol(String symbol, Named oldValue, Named newValue) {

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ConstantTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ConstantTest.java
@@ -66,7 +66,7 @@ public class ConstantTest {
         when(c.name()).thenReturn("aBool");
         when(c.type()).thenReturn(ThriftType.BOOL);
 
-        when(linker.lookupSymbol("aBool")).thenReturn(c);
+        when(linker.lookupConst("aBool")).thenReturn(c);
 
         Constant.validate(linker, ConstValueElement.identifier(loc, "aBool"), ThriftType.BOOL);
     }
@@ -107,7 +107,7 @@ public class ConstantTest {
         when(c.name()).thenReturn("aBool");
         when(c.type()).thenReturn(ThriftType.typedefOf(ThriftType.BOOL, "Truthiness"));
 
-        when(linker.lookupSymbol("aBool")).thenReturn(c);
+        when(linker.lookupConst("aBool")).thenReturn(c);
 
         Constant.validate(linker, ConstValueElement.identifier(loc, "aBool"), ThriftType.BOOL);
     }

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -735,6 +735,57 @@ public class LoaderTest {
         }
     }
 
+    @Test
+    public void constAndTypeWithSameName() throws Exception {
+        String thrift = "" +
+                "namespace java thrifty.constants\n" +
+                "\n" +
+                "const Foo Foo = Foo.BAR;\n" +
+                "\n" +
+                "enum Foo {\n" +
+                "  BAR,\n" +
+                "  BAZ\n" +
+                "}\n" +
+                "\n" +
+                "struct FooBar {\n" +
+                "  1: required Foo Foo = Foo,\n" +
+                "  2: required Foo Bar = Foo.BAR,\n" +
+                "}\n";
+
+        load(thrift);
+    }
+
+    @Test
+    public void booleanConstValidation() throws Exception {
+        String thrift = "" +
+                "namespace java thrifty.constants\n" +
+                "\n" +
+                "const bool B = true;\n" +
+                "\n" +
+                "struct Foo {\n" +
+                "  1: required bool value = B\n" +
+                "}\n";
+
+        load(thrift);
+    }
+
+    @Test
+    public void typedefOfBooleanConstValidation() throws Exception {
+        // TODO: Does this actually work in the Apache compiler?
+        String thrift = "" +
+                "namespace java thrifty.constants\n" +
+                "\n" +
+                "typedef bool MyBool" +
+                "\n" +
+                "const MyBool B = true;\n" +
+                "\n" +
+                "struct Foo {\n" +
+                "  1: required bool value = B\n" +
+                "}\n";
+
+        load(thrift);
+    }
+
     private Schema load(String thrift) throws Exception {
         File f = tempDir.newFile();
         writeTo(f, thrift);


### PR DESCRIPTION
This practice, while of dubious merit, is legal in Thrift; this PR
adds support.

This took a surprising amount of effort; before, we have always assumed
that a single name would map to at most one `Named` instance - now,
that is no longer the case.  `Linker` correspondingly has grown a new
lookup method, and things that use it (i.e. `Constant` validation) now
need to ensure that they use the correct lookup method.