### PR TITLE
Add Builders to Schema Components 

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -90,6 +90,24 @@ public class Constant extends Named {
         Validators.forType(trueExpectedType).validate(linker, trueExpectedType, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        Constant constant = (Constant) o;
+
+        if (element != null ? !element.equals(constant.element) : constant.element != null) { return false; }
+        return type != null ? type.equals(constant.type) : constant.type == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element != null ? element.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+
     interface ConstValueValidator {
         void validate(Linker linker, ThriftType expected, ConstValueElement value);
     }
@@ -108,6 +126,9 @@ public class Constant extends Named {
         }
 
         public Builder element(ConstElement element) {
+            if (element == null) {
+                throw new NullPointerException("element may not be null.");
+            }
             this.element = element;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -38,7 +38,7 @@ public class Constant extends Named {
         this.namespaces = namespaces;
     }
 
-    public Constant(Builder builder) {
+    private Constant(Builder builder) {
         super(builder.element.name(), builder.namespaces);
         this.element = builder.element;
         this.namespaces = builder.namespaces;
@@ -97,12 +97,12 @@ public class Constant extends Named {
         void validate(Linker linker, ThriftType expected, ConstValueElement value);
     }
 
-    private static final class Builder {
+    public static final class Builder {
         private ConstElement element;
         private Map<NamespaceScope, String> namespaces;
         private ThriftType type;
 
-        public Builder(ConstElement element,
+        Builder(ConstElement element,
                        Map<NamespaceScope, String> namespaces,
                        ThriftType type) {
             this.element = element;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -29,11 +29,20 @@ import java.util.Map;
 
 public class Constant extends Named {
     private final ConstElement element;
+    private final Map<NamespaceScope, String> namespaces;
     private ThriftType type;
 
     Constant(ConstElement element, Map<NamespaceScope, String> namespaces) {
         super(element.name(), namespaces);
         this.element = element;
+        this.namespaces = namespaces;
+    }
+
+    public Constant(Builder builder) {
+        super(builder.element.name(), builder.namespaces);
+        this.element = builder.element;
+        this.namespaces = builder.namespaces;
+        this.type = builder.type;
     }
 
     @Override
@@ -52,6 +61,10 @@ public class Constant extends Named {
 
     public ConstValueElement value() {
         return element.value();
+    }
+
+    public Builder toBuilder(Constant constant) {
+        return new Builder(constant.element, constant.namespaces(), constant.type);
     }
 
     void link(Linker linker) {
@@ -82,6 +95,39 @@ public class Constant extends Named {
 
     interface ConstValueValidator {
         void validate(Linker linker, ThriftType expected, ConstValueElement value);
+    }
+
+    private static final class Builder {
+        private ConstElement element;
+        private Map<NamespaceScope, String> namespaces;
+        private ThriftType type;
+
+        public Builder(ConstElement element,
+                       Map<NamespaceScope, String> namespaces,
+                       ThriftType type) {
+            this.element = element;
+            this.namespaces = namespaces;
+            this.type = type;
+        }
+
+        public Builder setElement(ConstElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+            this.namespaces = namespaces;
+            return this;
+        }
+
+        public Builder setType(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Constant build() {
+            return new Constant(this);
+        }
     }
 
     private static class Validators {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -110,17 +110,17 @@ public class Constant extends Named {
             this.type = type;
         }
 
-        public Builder setElement(ConstElement element) {
+        public Builder element(ConstElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+        public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
             return this;
         }
 
-        public Builder setType(ThriftType type) {
+        public Builder type(ThriftType type) {
             this.type = type;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -63,8 +63,8 @@ public class Constant extends Named {
         return element.value();
     }
 
-    public Builder toBuilder(Constant constant) {
-        return new Builder(constant.element, constant.namespaces(), constant.type);
+    public Builder toBuilder() {
+        return new Builder(element, namespaces(), type);
     }
 
     void link(Linker linker) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -92,12 +92,18 @@ public class Constant extends Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Constant constant = (Constant) o;
 
-        if (element != null ? !element.equals(constant.element) : constant.element != null) { return false; }
+        if (element != null ? !element.equals(constant.element) : constant.element != null) {
+            return false;
+        }
         return type != null ? type.equals(constant.type) : constant.type == null;
     }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -29,19 +29,16 @@ import java.util.Map;
 
 public class Constant extends Named {
     private final ConstElement element;
-    private final Map<NamespaceScope, String> namespaces;
     private ThriftType type;
 
     Constant(ConstElement element, Map<NamespaceScope, String> namespaces) {
         super(element.name(), namespaces);
         this.element = element;
-        this.namespaces = namespaces;
     }
 
     private Constant(Builder builder) {
         super(builder.element.name(), builder.namespaces);
         this.element = builder.element;
-        this.namespaces = builder.namespaces;
         this.type = builder.type;
     }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -112,6 +112,29 @@ public class EnumType extends Named {
                 || annotations.containsKey("thrifty.deprecated");
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        EnumType enumType = (EnumType) o;
+
+        if (!element.equals(enumType.element)) { return false; }
+        if (type != null ? !type.equals(enumType.type) : enumType.type != null) { return false; }
+        if (members != null ? !members.equals(enumType.members) : enumType.members != null) { return false; }
+        return annotations != null ? annotations.equals(enumType.annotations) : enumType.annotations == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element.hashCode();
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (members != null ? members.hashCode() : 0);
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        return result;
+    }
+
     public Builder toBuilder() {
         return new Builder(element,
                 type,
@@ -140,6 +163,9 @@ public class EnumType extends Named {
         }
 
         public Builder element(EnumElement element) {
+            if (element == null) {
+                throw new NullPointerException("element may not be null.");
+            }
             this.element = element;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -36,12 +36,14 @@ public class EnumType extends Named {
     private final ThriftType type;
     private final ImmutableList<Member> members;
     private final ImmutableMap<String, String> annotations;
+    private final Map<NamespaceScope, String> namespaces;
 
     @VisibleForTesting
     EnumType(EnumElement element, ThriftType type, Map<NamespaceScope, String> namespaces) {
         super(element.name(), namespaces);
         this.element = element;
         this.type = type;
+        this.namespaces = namespaces;
 
         ImmutableList.Builder<Member> membersBuilder = ImmutableList.builder();
         for (EnumMemberElement memberElement : element.members()) {
@@ -55,6 +57,15 @@ public class EnumType extends Named {
             annotationBuilder.putAll(anno.values());
         }
         this.annotations = annotationBuilder.build();
+    }
+
+    private EnumType(Builder builder) {
+        super(builder.element.name(), builder.namespaces);
+        this.element = builder.element;
+        this.type = builder.type;
+        this.members = builder.members;
+        this.annotations = builder.annotations;
+        this.namespaces = builder.namespaces;
     }
 
     public String documentation() {
@@ -102,6 +113,63 @@ public class EnumType extends Named {
         return super.isDeprecated()
                 || annotations.containsKey("deprecated")
                 || annotations.containsKey("thrifty.deprecated");
+    }
+
+    public Builder toBuilder(EnumType enumType) {
+        return new Builder(enumType.element,
+                enumType.type,
+                enumType.members,
+                enumType.annotations,
+                enumType.namespaces);
+    }
+
+    public static final class Builder {
+        private EnumElement element;
+        private ThriftType type;
+        private ImmutableList<Member> members;
+        private ImmutableMap<String, String> annotations;
+        private Map<NamespaceScope, String> namespaces;
+
+        public Builder(EnumElement element,
+                       ThriftType type,
+                       ImmutableList<Member> members,
+                       ImmutableMap<String, String> annotations,
+                       Map<NamespaceScope, String> namespaces) {
+            this.element = element;
+            this.type = type;
+            this.members = members;
+            this.annotations = annotations;
+            this.namespaces = namespaces;
+        }
+
+        public Builder setElement(EnumElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setType(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setMembers(ImmutableList<Member> members) {
+            this.members = members;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+            this.namespaces = namespaces;
+            return this;
+        }
+
+        public EnumType build() {
+            return new EnumType(this);
+        }
     }
 
     public static final class Member {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -114,14 +114,24 @@ public class EnumType extends Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         EnumType enumType = (EnumType) o;
 
-        if (!element.equals(enumType.element)) { return false; }
-        if (type != null ? !type.equals(enumType.type) : enumType.type != null) { return false; }
-        if (members != null ? !members.equals(enumType.members) : enumType.members != null) { return false; }
+        if (!element.equals(enumType.element)) {
+            return false;
+        }
+        if (type != null ? !type.equals(enumType.type) : enumType.type != null) {
+            return false;
+        }
+        if (members != null ? !members.equals(enumType.members) : enumType.members != null) {
+            return false;
+        }
         return annotations != null ? annotations.equals(enumType.annotations) : enumType.annotations == null;
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -36,14 +36,12 @@ public class EnumType extends Named {
     private final ThriftType type;
     private final ImmutableList<Member> members;
     private final ImmutableMap<String, String> annotations;
-    private final Map<NamespaceScope, String> namespaces;
 
     @VisibleForTesting
     EnumType(EnumElement element, ThriftType type, Map<NamespaceScope, String> namespaces) {
         super(element.name(), namespaces);
         this.element = element;
         this.type = type;
-        this.namespaces = namespaces;
 
         ImmutableList.Builder<Member> membersBuilder = ImmutableList.builder();
         for (EnumMemberElement memberElement : element.members()) {
@@ -65,7 +63,6 @@ public class EnumType extends Named {
         this.type = builder.type;
         this.members = builder.members;
         this.annotations = builder.annotations;
-        this.namespaces = builder.namespaces;
     }
 
     public String documentation() {
@@ -120,7 +117,7 @@ public class EnumType extends Named {
                 type,
                 members,
                 annotations,
-                namespaces);
+                namespaces());
     }
 
     public static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -142,27 +142,27 @@ public class EnumType extends Named {
             this.namespaces = namespaces;
         }
 
-        public Builder setElement(EnumElement element) {
+        public Builder element(EnumElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setType(ThriftType type) {
+        public Builder type(ThriftType type) {
             this.type = type;
             return this;
         }
 
-        public Builder setMembers(ImmutableList<Member> members) {
+        public Builder members(ImmutableList<Member> members) {
             this.members = members;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }
 
-        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+        public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -130,7 +130,7 @@ public class EnumType extends Named {
         private ImmutableMap<String, String> annotations;
         private Map<NamespaceScope, String> namespaces;
 
-        public Builder(EnumElement element,
+        Builder(EnumElement element,
                        ThriftType type,
                        ImmutableList<Member> members,
                        ImmutableMap<String, String> annotations,

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -115,12 +115,12 @@ public class EnumType extends Named {
                 || annotations.containsKey("thrifty.deprecated");
     }
 
-    public Builder toBuilder(EnumType enumType) {
-        return new Builder(enumType.element,
-                enumType.type,
-                enumType.members,
-                enumType.annotations,
-                enumType.namespaces);
+    public Builder toBuilder() {
+        return new Builder(element,
+                type,
+                members,
+                annotations,
+                namespaces);
     }
 
     public static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -148,6 +148,9 @@ public final class Field {
         }
 
         public Builder element(FieldElement element) {
+            if (element == null) {
+                throw new NullPointerException("element may not be null.");
+            }
             this.element = element;
             return this;
         }
@@ -198,5 +201,31 @@ public final class Field {
                 linker.addError(value.location(), e.getMessage());
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        Field field = (Field) o;
+
+        if (!element.equals(field.element)) { return false; }
+        if (fieldNamingPolicy != null ? !fieldNamingPolicy.equals(field.fieldNamingPolicy) :
+                field.fieldNamingPolicy != null) { return false; }
+        if (annotations != null ? !annotations.equals(field.annotations) : field.annotations != null) { return false; }
+        if (type != null ? !type.equals(field.type) : field.type != null) { return false; }
+        return javaName != null ? javaName.equals(field.javaName) : field.javaName == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element.hashCode();
+        result = 31 * result + (fieldNamingPolicy != null ? fieldNamingPolicy.hashCode() : 0);
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (javaName != null ? javaName.hashCode() : 0);
+        return result;
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -205,16 +205,28 @@ public final class Field {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Field field = (Field) o;
 
-        if (!element.equals(field.element)) { return false; }
-        if (fieldNamingPolicy != null ? !fieldNamingPolicy.equals(field.fieldNamingPolicy) :
-                field.fieldNamingPolicy != null) { return false; }
-        if (annotations != null ? !annotations.equals(field.annotations) : field.annotations != null) { return false; }
-        if (type != null ? !type.equals(field.type) : field.type != null) { return false; }
+        if (!element.equals(field.element)) {
+            return false;
+        }
+        if (fieldNamingPolicy != null ? !fieldNamingPolicy.equals(field.fieldNamingPolicy)
+                : field.fieldNamingPolicy != null) {
+            return false;
+        }
+        if (annotations != null ? !annotations.equals(field.annotations) : field.annotations != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(field.type) : field.type != null) {
+            return false;
+        }
         return javaName != null ? javaName.equals(field.javaName) : field.javaName == null;
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -25,8 +25,9 @@ import com.microsoft.thrifty.schema.parser.AnnotationElement;
 import com.microsoft.thrifty.schema.parser.ConstValueElement;
 import com.microsoft.thrifty.schema.parser.FieldElement;
 
-import javax.annotation.Nullable;
 import java.util.Locale;
+
+import javax.annotation.Nullable;
 
 public final class Field {
     private final FieldElement element;
@@ -146,22 +147,22 @@ public final class Field {
             this.type = type;
         }
 
-        public Builder setElement(FieldElement element) {
+        public Builder element(FieldElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setFieldNamingPolicy(FieldNamingPolicy fieldNamingPolicy) {
+        public Builder fieldNamingPolicy(FieldNamingPolicy fieldNamingPolicy) {
             this.fieldNamingPolicy = fieldNamingPolicy;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }
 
-        public Builder setType(ThriftType type) {
+        public Builder type(ThriftType type) {
             this.type = type;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -127,8 +127,8 @@ public final class Field {
                 || (hasJavadoc() && documentation().toLowerCase(Locale.US).contains("@deprecated"));
     }
 
-    public Builder toBuilder(Field field) {
-        return new Builder(field.element, field.fieldNamingPolicy, field.annotations, field.type);
+    public Builder toBuilder() {
+        return new Builder(element, fieldNamingPolicy, annotations, type);
     }
 
     public static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -48,6 +48,13 @@ public final class Field {
         this.annotations = annotationBuilder.build();
     }
 
+    private Field(Builder builder) {
+        this.element = builder.element;
+        this.fieldNamingPolicy = builder.fieldNamingPolicy;
+        this.annotations = builder.annotations;
+        this.type = builder.type;
+    }
+
     public Location location() {
         return element.location();
     }
@@ -117,6 +124,51 @@ public final class Field {
         return annotations.containsKey("deprecated")
                 || annotations.containsKey("thrifty.deprecated")
                 || (hasJavadoc() && documentation().toLowerCase(Locale.US).contains("@deprecated"));
+    }
+
+    public Builder toBuilder(Field field) {
+        return new Builder(field.element, field.fieldNamingPolicy, field.annotations, field.type);
+    }
+
+    public static final class Builder {
+        private FieldElement element;
+        private FieldNamingPolicy fieldNamingPolicy;
+        private ImmutableMap<String, String> annotations;
+        private ThriftType type;
+
+        public Builder(FieldElement element,
+                       FieldNamingPolicy fieldNamingPolicy,
+                       ImmutableMap<String, String> annotations,
+                       ThriftType type) {
+            this.element = element;
+            this.fieldNamingPolicy = fieldNamingPolicy;
+            this.annotations = annotations;
+            this.type = type;
+        }
+
+        public Builder setElement(FieldElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setFieldNamingPolicy(FieldNamingPolicy fieldNamingPolicy) {
+            this.fieldNamingPolicy = fieldNamingPolicy;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder setType(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Field build() {
+            return new Field(this);
+        }
     }
 
     void setType(ThriftType type) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -136,7 +136,7 @@ public final class Field {
         private ImmutableMap<String, String> annotations;
         private ThriftType type;
 
-        public Builder(FieldElement element,
+        Builder(FieldElement element,
                        FieldNamingPolicy fieldNamingPolicy,
                        ImmutableMap<String, String> annotations,
                        ThriftType type) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -147,37 +147,37 @@ public class Schema {
             this.services = services;
         }
 
-        public Builder setStructs(ImmutableList<StructType> structs) {
+        public Builder structs(ImmutableList<StructType> structs) {
             this.structs = structs;
             return this;
         }
 
-        public Builder setUnions(ImmutableList<StructType> unions) {
+        public Builder unions(ImmutableList<StructType> unions) {
             this.unions = unions;
             return this;
         }
 
-        public Builder setExceptions(ImmutableList<StructType> exceptions) {
+        public Builder exceptions(ImmutableList<StructType> exceptions) {
             this.exceptions = exceptions;
             return this;
         }
 
-        public Builder setEnums(ImmutableList<EnumType> enums) {
+        public Builder enums(ImmutableList<EnumType> enums) {
             this.enums = enums;
             return this;
         }
 
-        public Builder setConstants(ImmutableList<Constant> constants) {
+        public Builder constants(ImmutableList<Constant> constants) {
             this.constants = constants;
             return this;
         }
 
-        public Builder setTypedefs(ImmutableList<Typedef> typedefs) {
+        public Builder typedefs(ImmutableList<Typedef> typedefs) {
             this.typedefs = typedefs;
             return this;
         }
 
-        public Builder setServices(ImmutableList<Service> services) {
+        public Builder services(ImmutableList<Service> services) {
             this.services = services;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -210,17 +210,33 @@ public class Schema {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Schema schema = (Schema) o;
 
-        if (!structs.equals(schema.structs)) { return false; }
-        if (!unions.equals(schema.unions)) { return false; }
-        if (!exceptions.equals(schema.exceptions)) { return false; }
-        if (!enums.equals(schema.enums)) { return false; }
-        if (!constants.equals(schema.constants)) { return false; }
-        if (!typedefs.equals(schema.typedefs)) { return false; }
+        if (!structs.equals(schema.structs)) {
+            return false;
+        }
+        if (!unions.equals(schema.unions)) {
+            return false;
+        }
+        if (!exceptions.equals(schema.exceptions)) {
+            return false;
+        }
+        if (!enums.equals(schema.enums)) {
+            return false;
+        }
+        if (!constants.equals(schema.constants)) {
+            return false;
+        }
+        if (!typedefs.equals(schema.typedefs)) {
+            return false;
+        }
         return services.equals(schema.services);
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -71,6 +71,16 @@ public class Schema {
         this.services = services.build();
     }
 
+    private Schema(Builder builder) {
+        this.structs = builder.structs;
+        this.unions = builder.unions;
+        this.exceptions = builder.exceptions;
+        this.enums = builder.enums;
+        this.constants = builder.constants;
+        this.typedefs = builder.typedefs;
+        this.services = builder.services;
+    }
+
     public ImmutableList<StructType> structs() {
         return structs;
     }
@@ -106,5 +116,74 @@ public class Schema {
             }
         }
         throw new NoSuchElementException("No enum type matching " + type.name());
+    }
+
+    public Builder toBuilder() {
+        return new Builder(structs, unions, exceptions, enums, constants, typedefs, services);
+    }
+
+    public static final class Builder {
+        private ImmutableList<StructType> structs;
+        private ImmutableList<StructType> unions;
+        private ImmutableList<StructType> exceptions;
+        private ImmutableList<EnumType> enums;
+        private ImmutableList<Constant> constants;
+        private ImmutableList<Typedef> typedefs;
+        private ImmutableList<Service> services;
+
+        Builder(ImmutableList<StructType> structs,
+                ImmutableList<StructType> unions,
+                ImmutableList<StructType> exceptions,
+                ImmutableList<EnumType> enums,
+                ImmutableList<Constant> constants,
+                ImmutableList<Typedef> typedefs,
+                ImmutableList<Service> services) {
+            this.structs = structs;
+            this.unions = unions;
+            this.exceptions = exceptions;
+            this.enums = enums;
+            this.constants = constants;
+            this.typedefs = typedefs;
+            this.services = services;
+        }
+
+        public Builder setStructs(ImmutableList<StructType> structs) {
+            this.structs = structs;
+            return this;
+        }
+
+        public Builder setUnions(ImmutableList<StructType> unions) {
+            this.unions = unions;
+            return this;
+        }
+
+        public Builder setExceptions(ImmutableList<StructType> exceptions) {
+            this.exceptions = exceptions;
+            return this;
+        }
+
+        public Builder setEnums(ImmutableList<EnumType> enums) {
+            this.enums = enums;
+            return this;
+        }
+
+        public Builder setConstants(ImmutableList<Constant> constants) {
+            this.constants = constants;
+            return this;
+        }
+
+        public Builder setTypedefs(ImmutableList<Typedef> typedefs) {
+            this.typedefs = typedefs;
+            return this;
+        }
+
+        public Builder setServices(ImmutableList<Service> services) {
+            this.services = services;
+            return this;
+        }
+
+        public Schema build() {
+            return new Schema(this);
+        }
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -207,4 +207,33 @@ public class Schema {
             return new Schema(this);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        Schema schema = (Schema) o;
+
+        if (!structs.equals(schema.structs)) { return false; }
+        if (!unions.equals(schema.unions)) { return false; }
+        if (!exceptions.equals(schema.exceptions)) { return false; }
+        if (!enums.equals(schema.enums)) { return false; }
+        if (!constants.equals(schema.constants)) { return false; }
+        if (!typedefs.equals(schema.typedefs)) { return false; }
+        return services.equals(schema.services);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = structs.hashCode();
+        result = 31 * result + unions.hashCode();
+        result = 31 * result + exceptions.hashCode();
+        result = 31 * result + enums.hashCode();
+        result = 31 * result + constants.hashCode();
+        result = 31 * result + typedefs.hashCode();
+        result = 31 * result + services.hashCode();
+        return result;
+    }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -148,36 +148,57 @@ public class Schema {
         }
 
         public Builder structs(ImmutableList<StructType> structs) {
+            if (structs == null) {
+                throw new NullPointerException("structs may not be null");
+            }
             this.structs = structs;
             return this;
         }
 
         public Builder unions(ImmutableList<StructType> unions) {
+            if (structs == null) {
+                throw new NullPointerException("unions may not be null");
+            }
             this.unions = unions;
             return this;
         }
 
         public Builder exceptions(ImmutableList<StructType> exceptions) {
+            if (structs == null) {
+                throw new NullPointerException("exceptions may not be null");
+            }
             this.exceptions = exceptions;
             return this;
         }
 
         public Builder enums(ImmutableList<EnumType> enums) {
+            if (structs == null) {
+                throw new NullPointerException("enums may not be null");
+            }
             this.enums = enums;
             return this;
         }
 
         public Builder constants(ImmutableList<Constant> constants) {
+            if (structs == null) {
+                throw new NullPointerException("constants may not be null");
+            }
             this.constants = constants;
             return this;
         }
 
         public Builder typedefs(ImmutableList<Typedef> typedefs) {
+            if (structs == null) {
+                throw new NullPointerException("typedefs may not be null");
+            }
             this.typedefs = typedefs;
             return this;
         }
 
         public Builder services(ImmutableList<Service> services) {
+            if (structs == null) {
+                throw new NullPointerException("services may not be null");
+            }
             this.services = services;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Schema.java
@@ -156,7 +156,7 @@ public class Schema {
         }
 
         public Builder unions(ImmutableList<StructType> unions) {
-            if (structs == null) {
+            if (unions == null) {
                 throw new NullPointerException("unions may not be null");
             }
             this.unions = unions;
@@ -164,7 +164,7 @@ public class Schema {
         }
 
         public Builder exceptions(ImmutableList<StructType> exceptions) {
-            if (structs == null) {
+            if (exceptions == null) {
                 throw new NullPointerException("exceptions may not be null");
             }
             this.exceptions = exceptions;
@@ -172,7 +172,7 @@ public class Schema {
         }
 
         public Builder enums(ImmutableList<EnumType> enums) {
-            if (structs == null) {
+            if (enums == null) {
                 throw new NullPointerException("enums may not be null");
             }
             this.enums = enums;
@@ -180,7 +180,7 @@ public class Schema {
         }
 
         public Builder constants(ImmutableList<Constant> constants) {
-            if (structs == null) {
+            if (constants == null) {
                 throw new NullPointerException("constants may not be null");
             }
             this.constants = constants;
@@ -188,7 +188,7 @@ public class Schema {
         }
 
         public Builder typedefs(ImmutableList<Typedef> typedefs) {
-            if (structs == null) {
+            if (typedefs == null) {
                 throw new NullPointerException("typedefs may not be null");
             }
             this.typedefs = typedefs;
@@ -196,7 +196,7 @@ public class Schema {
         }
 
         public Builder services(ImmutableList<Service> services) {
-            if (structs == null) {
+            if (services == null) {
                 throw new NullPointerException("services may not be null");
             }
             this.services = services;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -99,7 +99,7 @@ public final class Service extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, methods, type, annotations);
+        return new Builder(element, methods, type, annotations, namespaces());
     }
 
     public static final class Builder {
@@ -112,14 +112,19 @@ public final class Service extends Named {
         Builder(ServiceElement element,
                ImmutableList<ServiceMethod> methods,
                ThriftType type,
-               ImmutableMap<String, String> annotations) {
+               ImmutableMap<String, String> annotations,
+                Map<NamespaceScope, String> namespaces) {
             this.element = element;
             this.methods = methods;
             this.type = type;
             this.annotations = annotations;
+            this.namespaces = namespaces;
         }
 
         public Builder element(ServiceElement element) {
+            if (element == null) {
+                throw new NullPointerException("element may not be null");
+            }
             this.element = element;
             return this;
         }
@@ -233,16 +238,29 @@ public final class Service extends Named {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) return true;
-        if (!(other instanceof Service)) return false;
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
 
-        Service that = (Service) other;
-        return this.element.equals(that.element);
+        Service service = (Service) o;
+
+        if (!element.equals(service.element)) { return false; }
+        if (!methods.equals(service.methods)) { return false; }
+        if (type != null ? !type.equals(service.type) : service.type != null) { return false; }
+        if (annotations != null ? !annotations.equals(service.annotations) : service.annotations != null) {
+            return false;
+        }
+        return extendsService != null ? extendsService.equals(service.extendsService) : service.extendsService == null;
+
     }
 
     @Override
     public int hashCode() {
-        return this.element.hashCode();
+        int result = element.hashCode();
+        result = 31 * result + methods.hashCode();
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        result = 31 * result + (extendsService != null ? extendsService.hashCode() : 0);
+        return result;
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -125,6 +125,9 @@ public final class Service extends Named {
         }
 
         public Builder methods(ImmutableList<ServiceMethod> methods) {
+            if (methods == null) {
+                throw new NullPointerException("methods may not be null");
+            }
             this.methods = methods;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -64,6 +64,14 @@ public final class Service extends Named {
         this.annotations = annotationBuilder.build();
     }
 
+    private Service(Builder builder) {
+        super(builder.element.name(), builder.namespaces);
+        this.element = builder.element;
+        this.methods = builder.methods;
+        this.type = builder.type;
+        this.annotations = builder.annotations;
+    }
+
     @Override
     public ThriftType type() {
         return type;
@@ -88,6 +96,57 @@ public final class Service extends Named {
 
     public ImmutableMap<String, String> annotations() {
         return annotations;
+    }
+
+    public Builder toBuilder() {
+        return new Builder(element, methods, type, annotations);
+    }
+
+    public static final class Builder {
+        private ServiceElement element;
+        private ImmutableList<ServiceMethod> methods;
+        private ThriftType type;
+        private ImmutableMap<String, String> annotations;
+        private Map<NamespaceScope, String> namespaces;
+
+        Builder(ServiceElement element,
+               ImmutableList<ServiceMethod> methods,
+               ThriftType type,
+               ImmutableMap<String, String> annotations) {
+            this.element = element;
+            this.methods = methods;
+            this.type = type;
+            this.annotations = annotations;
+        }
+
+        public Builder setElement(ServiceElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setMethods(ImmutableList<ServiceMethod> methods) {
+            this.methods = methods;
+            return this;
+        }
+
+        public Builder setType(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+            this.namespaces = namespaces;
+            return this;
+        }
+
+        public Service build() {
+            return new Service(this);
+        }
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -119,27 +119,27 @@ public final class Service extends Named {
             this.annotations = annotations;
         }
 
-        public Builder setElement(ServiceElement element) {
+        public Builder element(ServiceElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setMethods(ImmutableList<ServiceMethod> methods) {
+        public Builder methods(ImmutableList<ServiceMethod> methods) {
             this.methods = methods;
             return this;
         }
 
-        public Builder setType(ThriftType type) {
+        public Builder type(ThriftType type) {
             this.type = type;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }
 
-        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+        public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -239,14 +239,24 @@ public final class Service extends Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Service service = (Service) o;
 
-        if (!element.equals(service.element)) { return false; }
-        if (!methods.equals(service.methods)) { return false; }
-        if (type != null ? !type.equals(service.type) : service.type != null) { return false; }
+        if (!element.equals(service.element)) {
+            return false;
+        }
+        if (!methods.equals(service.methods)) {
+            return false;
+        }
+        if (type != null ? !type.equals(service.type) : service.type != null) {
+            return false;
+        }
         if (annotations != null ? !annotations.equals(service.annotations) : service.annotations != null) {
             return false;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -124,22 +124,22 @@ public final class ServiceMethod {
             this.annotations = annotations;
         }
 
-        public Builder setElement(FunctionElement element) {
+        public Builder element(FunctionElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setParamTypes(ImmutableList<Field> paramTypes) {
+        public Builder paramTypes(ImmutableList<Field> paramTypes) {
             this.paramTypes = paramTypes;
             return this;
         }
 
-        public Builder setExceptionTypes(ImmutableList<Field> exceptionTypes) {
+        public Builder exceptionTypes(ImmutableList<Field> exceptionTypes) {
             this.exceptionTypes = exceptionTypes;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -114,7 +114,7 @@ public final class ServiceMethod {
         private ImmutableList<Field> exceptionTypes;
         private ImmutableMap<String, String> annotations;
 
-        public Builder(FunctionElement element,
+        Builder(FunctionElement element,
                        ImmutableList<Field> paramTypes,
                        ImmutableList<Field> exceptionTypes,
                        ImmutableMap<String, String> annotations) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -216,17 +216,27 @@ public final class ServiceMethod {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ServiceMethod that = (ServiceMethod) o;
 
-        if (!element.equals(that.element)) { return false; }
-        if (paramTypes != null ? !paramTypes.equals(that.paramTypes) : that.paramTypes != null) { return false; }
+        if (!element.equals(that.element)) {
+            return false;
+        }
+        if (paramTypes != null ? !paramTypes.equals(that.paramTypes) : that.paramTypes != null) {
+            return false;
+        }
         if (exceptionTypes != null ? !exceptionTypes.equals(that.exceptionTypes) : that.exceptionTypes != null) {
             return false;
         }
-        if (annotations != null ? !annotations.equals(that.annotations) : that.annotations != null) { return false; }
+        if (annotations != null ? !annotations.equals(that.annotations) : that.annotations != null) {
+            return false;
+        }
         return returnType != null ? returnType.equals(that.returnType) : that.returnType == null;
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -125,6 +125,9 @@ public final class ServiceMethod {
         }
 
         public Builder element(FunctionElement element) {
+            if (element == null) {
+                throw new NullPointerException("element can't be null.");
+            }
             this.element = element;
             return this;
         }
@@ -209,5 +212,32 @@ public final class ServiceMethod {
 
             linker.addError(field.location(), "Only exception types can be thrown");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        ServiceMethod that = (ServiceMethod) o;
+
+        if (!element.equals(that.element)) { return false; }
+        if (paramTypes != null ? !paramTypes.equals(that.paramTypes) : that.paramTypes != null) { return false; }
+        if (exceptionTypes != null ? !exceptionTypes.equals(that.exceptionTypes) : that.exceptionTypes != null) {
+            return false;
+        }
+        if (annotations != null ? !annotations.equals(that.annotations) : that.annotations != null) { return false; }
+        return returnType != null ? returnType.equals(that.returnType) : that.returnType == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element.hashCode();
+        result = 31 * result + (paramTypes != null ? paramTypes.hashCode() : 0);
+        result = 31 * result + (exceptionTypes != null ? exceptionTypes.hashCode() : 0);
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        result = 31 * result + (returnType != null ? returnType.hashCode() : 0);
+        return result;
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -61,6 +61,13 @@ public final class ServiceMethod {
         this.annotations = annotationBuilder.build();
     }
 
+    private ServiceMethod(Builder builder) {
+        this.element = builder.element;
+        this.paramTypes = builder.paramTypes;
+        this.exceptionTypes = builder.exceptionTypes;
+        this.annotations = builder.annotations;
+    }
+
     public Location location() {
         return element.location();
     }
@@ -95,6 +102,51 @@ public final class ServiceMethod {
 
     public ImmutableMap<String, String> annotations() {
         return annotations;
+    }
+
+    public Builder toBuilder() {
+        return new Builder(element, paramTypes, exceptionTypes, annotations);
+    }
+
+    public static final class Builder {
+        private FunctionElement element;
+        private ImmutableList<Field> paramTypes;
+        private ImmutableList<Field> exceptionTypes;
+        private ImmutableMap<String, String> annotations;
+
+        public Builder(FunctionElement element,
+                       ImmutableList<Field> paramTypes,
+                       ImmutableList<Field> exceptionTypes,
+                       ImmutableMap<String, String> annotations) {
+            this.element = element;
+            this.paramTypes = paramTypes;
+            this.exceptionTypes = exceptionTypes;
+            this.annotations = annotations;
+        }
+
+        public Builder setElement(FunctionElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setParamTypes(ImmutableList<Field> paramTypes) {
+            this.paramTypes = paramTypes;
+            return this;
+        }
+
+        public Builder setExceptionTypes(ImmutableList<Field> exceptionTypes) {
+            this.exceptionTypes = exceptionTypes;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public ServiceMethod build() {
+            return new ServiceMethod(this);
+        }
     }
 
     void link(Linker linker) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -166,14 +166,24 @@ public class StructType extends Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         StructType that = (StructType) o;
 
-        if (!element.equals(that.element)) { return false; }
-        if (type != null ? !type.equals(that.type) : that.type != null) { return false; }
-        if (fields != null ? !fields.equals(that.fields) : that.fields != null) { return false; }
+        if (!element.equals(that.element)) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (fields != null ? !fields.equals(that.fields) : that.fields != null) {
+            return false;
+        }
         return annotations != null ? annotations.equals(that.annotations) : that.annotations == null;
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -104,12 +104,8 @@ public class StructType extends Named {
         return element.type() == StructElement.Type.EXCEPTION;
     }
 
-    public Builder toBuilder(StructType structType) {
-        return new Builder(structType.element,
-                structType.type,
-                structType.fields,
-                structType.annotations,
-                structType.namespaces);
+    public Builder toBuilder() {
+        return new Builder(element, type,fields, annotations, namespaces);
     }
 
     private static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -34,6 +34,7 @@ public class StructType extends Named {
     private final ThriftType type;
     private final ImmutableList<Field> fields;
     private final ImmutableMap<String, String> annotations;
+    private final Map<NamespaceScope, String> namespaces;
 
     StructType(
             StructElement element,
@@ -43,6 +44,7 @@ public class StructType extends Named {
         super(element.name(), namespaces);
         this.element = element;
         this.type = type;
+        this.namespaces = namespaces;
 
         ImmutableList.Builder<Field> fieldsBuilder = ImmutableList.builder();
         for (FieldElement fieldElement : element.fields()) {
@@ -56,6 +58,15 @@ public class StructType extends Named {
             annotationBuilder.putAll(anno.values());
         }
         this.annotations = annotationBuilder.build();
+    }
+
+    private StructType(Builder builder) {
+        super(builder.element.name(), builder.namespaces);
+        this.element = builder.element;
+        this.type = builder.type;
+        this.fields = builder.fields;
+        this.annotations = builder.annotations;
+        this.namespaces = builder.namespaces;
     }
 
     @Override
@@ -91,6 +102,63 @@ public class StructType extends Named {
 
     public boolean isException() {
         return element.type() == StructElement.Type.EXCEPTION;
+    }
+
+    public Builder toBuilder(StructType structType) {
+        return new Builder(structType.element,
+                structType.type,
+                structType.fields,
+                structType.annotations,
+                structType.namespaces);
+    }
+
+    private static final class Builder {
+        private StructElement element;
+        private ThriftType type;
+        private ImmutableList<Field> fields;
+        private ImmutableMap<String, String> annotations;
+        private Map<NamespaceScope, String> namespaces;
+
+        public Builder(StructElement element,
+                       ThriftType type,
+                       ImmutableList<Field> fields,
+                       ImmutableMap<String, String> annotations,
+                       Map<NamespaceScope, String> namespaces) {
+            this.element = element;
+            this.type = type;
+            this.fields = fields;
+            this.annotations = annotations;
+            this.namespaces = namespaces;
+        }
+
+        public Builder setElement(StructElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setType(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setFields(ImmutableList<Field> fields) {
+            this.fields = fields;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+            this.namespaces = namespaces;
+            return this;
+        }
+
+        public StructType build() {
+            return new StructType(this);
+        }
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -131,27 +131,27 @@ public class StructType extends Named {
             this.namespaces = namespaces;
         }
 
-        public Builder setElement(StructElement element) {
+        public Builder element(StructElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setType(ThriftType type) {
+        public Builder type(ThriftType type) {
             this.type = type;
             return this;
         }
 
-        public Builder setFields(ImmutableList<Field> fields) {
+        public Builder fields(ImmutableList<Field> fields) {
             this.fields = fields;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }
 
-        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+        public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -102,7 +102,7 @@ public class StructType extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, type,fields, annotations, namespaces());
+        return new Builder(element, type, fields, annotations, namespaces());
     }
 
     private static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -119,7 +119,7 @@ public class StructType extends Named {
         private ImmutableMap<String, String> annotations;
         private Map<NamespaceScope, String> namespaces;
 
-        public Builder(StructElement element,
+        Builder(StructElement element,
                        ThriftType type,
                        ImmutableList<Field> fields,
                        ImmutableMap<String, String> annotations,

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -34,7 +34,6 @@ public class StructType extends Named {
     private final ThriftType type;
     private final ImmutableList<Field> fields;
     private final ImmutableMap<String, String> annotations;
-    private final Map<NamespaceScope, String> namespaces;
 
     StructType(
             StructElement element,
@@ -44,7 +43,6 @@ public class StructType extends Named {
         super(element.name(), namespaces);
         this.element = element;
         this.type = type;
-        this.namespaces = namespaces;
 
         ImmutableList.Builder<Field> fieldsBuilder = ImmutableList.builder();
         for (FieldElement fieldElement : element.fields()) {
@@ -66,7 +64,6 @@ public class StructType extends Named {
         this.type = builder.type;
         this.fields = builder.fields;
         this.annotations = builder.annotations;
-        this.namespaces = builder.namespaces;
     }
 
     @Override
@@ -105,7 +102,7 @@ public class StructType extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, type,fields, annotations, namespaces);
+        return new Builder(element, type,fields, annotations, namespaces());
     }
 
     private static final class Builder {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -105,7 +105,7 @@ public class StructType extends Named {
         return new Builder(element, type, fields, annotations, namespaces());
     }
 
-    private static final class Builder {
+    public static final class Builder {
         private StructElement element;
         private ThriftType type;
         private ImmutableList<Field> fields;
@@ -125,6 +125,9 @@ public class StructType extends Named {
         }
 
         public Builder element(StructElement element) {
+            if (element == null) {
+                throw new NullPointerException("element can't be null.");
+            }
             this.element = element;
             return this;
         }
@@ -159,6 +162,29 @@ public class StructType extends Named {
         return super.isDeprecated()
                 || annotations.containsKey("deprecated")
                 || annotations.containsKey("thrifty.deprecated");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        StructType that = (StructType) o;
+
+        if (!element.equals(that.element)) { return false; }
+        if (type != null ? !type.equals(that.type) : that.type != null) { return false; }
+        if (fields != null ? !fields.equals(that.fields) : that.fields != null) { return false; }
+        return annotations != null ? annotations.equals(that.annotations) : that.annotations == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element.hashCode();
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (fields != null ? fields.hashCode() : 0);
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        return result;
     }
 
     void link(Linker linker) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -46,7 +46,7 @@ public final class Typedef extends Named {
         this.annotations = annotationBuilder.build();
     }
 
-    public Typedef(Builder builder) {
+    private Typedef(Builder builder) {
         this(builder.element, builder.namespaces);
     }
 
@@ -96,7 +96,7 @@ public final class Typedef extends Named {
         private ImmutableMap<String, String> annotations;
         private Map<NamespaceScope, String> namespaces;
 
-        public Builder(TypedefElement element,
+        Builder(TypedefElement element,
                        ImmutableMap<String, String> annotations,
                        Map<NamespaceScope, String> namespaces) {
             this.element = element;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -93,16 +93,24 @@ public final class Typedef extends Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Typedef typedef = (Typedef) o;
 
-        if (!element.equals(typedef.element)) { return false; }
+        if (!element.equals(typedef.element)) {
+            return false;
+        }
         if (annotations != null ? !annotations.equals(typedef.annotations) : typedef.annotations != null) {
             return false;
         }
-        if (oldType != null ? !oldType.equals(typedef.oldType) : typedef.oldType != null) { return false; }
+        if (oldType != null ? !oldType.equals(typedef.oldType) : typedef.oldType != null) {
+            return false;
+        }
         return type != null ? type.equals(typedef.type) : typedef.type == null;
 
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -47,7 +47,10 @@ public final class Typedef extends Named {
     }
 
     private Typedef(Builder builder) {
-        this(builder.element, builder.namespaces);
+        super(builder.element.newName(), builder.namespaces);
+        this.element = builder.element;
+        this.annotations = builder.annotations;
+        this.namespaces= builder.namespaces;
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -50,7 +50,7 @@ public final class Typedef extends Named {
         super(builder.element.newName(), builder.namespaces);
         this.element = builder.element;
         this.annotations = builder.annotations;
-        this.namespaces= builder.namespaces;
+        this.namespaces = builder.namespaces;
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -84,8 +84,8 @@ public final class Typedef extends Named {
         return oldType.annotations();
     }
 
-    public Builder toBuilder(Typedef typeDef) {
-        return new Builder(typeDef.element, typeDef.annotations, typeDef.namespaces);
+    public Builder toBuilder() {
+        return new Builder(element, annotations, namespaces);
     }
 
     boolean link(Linker linker) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -91,6 +91,31 @@ public final class Typedef extends Named {
         return true;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        Typedef typedef = (Typedef) o;
+
+        if (!element.equals(typedef.element)) { return false; }
+        if (annotations != null ? !annotations.equals(typedef.annotations) : typedef.annotations != null) {
+            return false;
+        }
+        if (oldType != null ? !oldType.equals(typedef.oldType) : typedef.oldType != null) { return false; }
+        return type != null ? type.equals(typedef.type) : typedef.type == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = element.hashCode();
+        result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+        result = 31 * result + (oldType != null ? oldType.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+
     public static final class Builder {
         private TypedefElement element;
         private ImmutableMap<String, String> annotations;
@@ -105,6 +130,9 @@ public final class Typedef extends Named {
         }
 
         public Builder element(TypedefElement element) {
+            if (element == null) {
+                throw new NullPointerException("element can't be null.");
+            }
             this.element = element;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -29,12 +29,14 @@ import java.util.Map;
 public final class Typedef extends Named {
     private final TypedefElement element;
     private final ImmutableMap<String, String> annotations;
+    private final Map<NamespaceScope, String> namespaces;
     private ThriftType oldType;
     private ThriftType type;
 
     Typedef(TypedefElement element, Map<NamespaceScope, String> namespaces) {
         super(element.newName(), namespaces);
         this.element = element;
+        this.namespaces = namespaces;
 
         ImmutableMap.Builder<String, String> annotationBuilder = ImmutableMap.builder();
         AnnotationElement anno = element.annotations();
@@ -42,6 +44,10 @@ public final class Typedef extends Named {
             annotationBuilder.putAll(anno.values());
         }
         this.annotations = annotationBuilder.build();
+    }
+
+    public Typedef(Builder builder) {
+        this(builder.element, builder.namespaces);
     }
 
     @Override
@@ -75,9 +81,46 @@ public final class Typedef extends Named {
         return oldType.annotations();
     }
 
+    public Builder toBuilder(Typedef typeDef) {
+        return new Builder(typeDef.element, typeDef.annotations, typeDef.namespaces);
+    }
+
     boolean link(Linker linker) {
         oldType = linker.resolveType(element.oldType());
         type = ThriftType.typedefOf(oldType, element.newName());
         return true;
+    }
+
+    public static final class Builder {
+        private TypedefElement element;
+        private ImmutableMap<String, String> annotations;
+        private Map<NamespaceScope, String> namespaces;
+
+        public Builder(TypedefElement element,
+                       ImmutableMap<String, String> annotations,
+                       Map<NamespaceScope, String> namespaces) {
+            this.element = element;
+            this.annotations = annotations;
+            this.namespaces = namespaces;
+        }
+
+        public Builder setElement(TypedefElement element) {
+            this.element = element;
+            return this;
+        }
+
+        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+            this.namespaces = namespaces;
+            return this;
+        }
+
+        public Typedef build() {
+            return new Typedef(this);
+        }
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -107,17 +107,17 @@ public final class Typedef extends Named {
             this.namespaces = namespaces;
         }
 
-        public Builder setElement(TypedefElement element) {
+        public Builder element(TypedefElement element) {
             this.element = element;
             return this;
         }
 
-        public Builder setAnnotations(ImmutableMap<String, String> annotations) {
+        public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
             return this;
         }
 
-        public Builder setNamespaces(Map<NamespaceScope, String> namespaces) {
+        public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
             return this;
         }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -29,14 +29,12 @@ import java.util.Map;
 public final class Typedef extends Named {
     private final TypedefElement element;
     private final ImmutableMap<String, String> annotations;
-    private final Map<NamespaceScope, String> namespaces;
     private ThriftType oldType;
     private ThriftType type;
 
     Typedef(TypedefElement element, Map<NamespaceScope, String> namespaces) {
         super(element.newName(), namespaces);
         this.element = element;
-        this.namespaces = namespaces;
 
         ImmutableMap.Builder<String, String> annotationBuilder = ImmutableMap.builder();
         AnnotationElement anno = element.annotations();
@@ -50,7 +48,6 @@ public final class Typedef extends Named {
         super(builder.element.newName(), builder.namespaces);
         this.element = builder.element;
         this.annotations = builder.annotations;
-        this.namespaces = builder.namespaces;
     }
 
     @Override
@@ -85,7 +82,7 @@ public final class Typedef extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, annotations, namespaces);
+        return new Builder(element, annotations, namespaces());
     }
 
     boolean link(Linker linker) {

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ConstantTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ConstantTest.java
@@ -21,8 +21,10 @@
 package com.microsoft.thrifty.schema;
 
 import com.google.common.collect.ImmutableList;
+import com.microsoft.thrifty.schema.parser.ConstElement;
 import com.microsoft.thrifty.schema.parser.ConstValueElement;
 import com.microsoft.thrifty.schema.parser.EnumMemberElement;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +34,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
@@ -288,4 +292,35 @@ public class ConstantTest {
 
         Constant.validate(linker, listValue, setType);
     }
+
+    @Test
+    public void builderCreatesCorrectConstant() {
+        ConstElement constructorElement = mock(ConstElement.class);
+        when(constructorElement.name()).thenReturn("name");
+        Constant constant = new Constant(constructorElement, new HashMap<NamespaceScope, String>());
+
+        ConstElement constElement = mock(ConstElement.class);
+        when(constElement.name()).thenReturn("name");
+        Map<NamespaceScope, String> namespaces = mock(Map.class);
+        ThriftType thriftType = mock(ThriftType.class);
+
+        Constant builderConstant = constant.toBuilder()
+                .element(constElement)
+                .namespaces(namespaces)
+                .type(thriftType)
+                .build();
+
+        assertEquals(builderConstant.namespaces(), namespaces);
+        assertEquals(builderConstant.type(), thriftType);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectConstant() {
+        ConstElement constructorElement = mock(ConstElement.class);
+        when(constructorElement.name()).thenReturn("name");
+        Constant constant = new Constant(constructorElement, new HashMap<NamespaceScope, String>());
+
+        assertEquals(constant.toBuilder().build(), constant);
+    }
+
 }

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/EnumTypeTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/EnumTypeTest.java
@@ -37,6 +37,7 @@ public class EnumTypeTest {
     @Test
     public void builderCreatesCorrectEnumType() {
         EnumElement enumElement = mock(EnumElement.class);
+        when(enumElement.name()).thenReturn("name");
         ThriftType thriftType = mock(ThriftType.class);
         ImmutableList<EnumType.Member> members = ImmutableList.of();
         ImmutableMap<String, String> annotations = ImmutableMap.of();

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/EnumTypeTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/EnumTypeTest.java
@@ -1,0 +1,63 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.thrifty.schema.parser.EnumElement;
+import com.microsoft.thrifty.schema.parser.EnumMemberElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnumTypeTest {
+    @Mock EnumElement element;
+    @Mock ThriftType type;
+    @Mock Map<NamespaceScope, String> namespaces;
+
+    EnumType enumType;
+
+    @Before
+    public void setup() {
+        when(element.name()).thenReturn("name");
+        when(element.members()).thenReturn(ImmutableList.<EnumMemberElement>of());
+
+        enumType = new EnumType(element, type, namespaces);
+    }
+
+    @Test
+    public void builderCreatesCorrectEnumType() {
+        EnumElement enumElement = mock(EnumElement.class);
+        ThriftType thriftType = mock(ThriftType.class);
+        ImmutableList<EnumType.Member> members = ImmutableList.of();
+        ImmutableMap<String, String> annotations = ImmutableMap.of();
+        Map<NamespaceScope, String> namespaces = new HashMap<>();
+
+        EnumType builderEnumType = enumType.toBuilder()
+                .element(enumElement)
+                .type(thriftType)
+                .members(members)
+                .annotations(annotations)
+                .namespaces(namespaces)
+                .build();
+
+        assertEquals(builderEnumType.type(), thriftType);
+        assertEquals(builderEnumType.members(), members);
+        assertEquals(builderEnumType.annotations(), annotations);
+        assertEquals(builderEnumType.namespaces(), namespaces);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectEnumType() {
+        assertEquals(enumType.toBuilder().build(), enumType);
+    }
+}

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/FieldTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/FieldTest.java
@@ -20,6 +20,7 @@
  */
 package com.microsoft.thrifty.schema;
 
+import com.google.common.collect.ImmutableMap;
 import com.microsoft.thrifty.schema.parser.AnnotationElement;
 import com.microsoft.thrifty.schema.parser.FieldElement;
 import com.microsoft.thrifty.schema.parser.TypeElement;
@@ -27,8 +28,10 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class FieldTest {
     @Test
@@ -127,6 +130,33 @@ public class FieldTest {
 
         Field field = new Field(element, FieldNamingPolicy.DEFAULT);
         assertTrue(field.isObfuscated());
+    }
+
+    @Test
+    public void builderCreatesCorrectField() {
+        FieldElement fieldElement = mock(FieldElement.class);
+        FieldNamingPolicy fieldNamingPolicy = mock(FieldNamingPolicy.class);
+        Field field = new Field(fieldElement, fieldNamingPolicy);
+
+        ImmutableMap<String, String> annotations = ImmutableMap.of();
+        ThriftType thriftType = mock(ThriftType.class);
+
+        Field builderField = field.toBuilder()
+                .annotations(annotations)
+                .type(thriftType)
+                .build();
+
+        assertEquals(builderField.annotations(), annotations);
+        assertEquals(builderField.type(), thriftType);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectField() {
+        FieldElement fieldElement = mock(FieldElement.class);
+        FieldNamingPolicy fieldNamingPolicy = mock(FieldNamingPolicy.class);
+        Field field = new Field(fieldElement, fieldNamingPolicy);
+
+        assertEquals(field.toBuilder().build(), field);
     }
 
     private AnnotationElement annotation(String name) {

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/SchemaTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/SchemaTest.java
@@ -1,0 +1,60 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SchemaTest {
+    @Mock Iterable<Program> programs;
+    @Mock Iterator<Program> programIterator;
+
+    Schema schema;
+
+    @Before
+    public void setup() {
+        when(programs.iterator()).thenReturn(programIterator);
+        schema = new Schema(programs);
+    }
+
+    @Test
+    public void builderCreatesCorrectSchema() {
+        ImmutableList<StructType> structTypes = ImmutableList.of();
+        ImmutableList<EnumType> enumTypes = ImmutableList.of();
+        ImmutableList<Constant> constants = ImmutableList.of();
+        ImmutableList<Typedef> typedefs = ImmutableList.of();
+        ImmutableList<Service> services = ImmutableList.of();
+
+        Schema.Builder builder = schema.toBuilder();
+        builder.structs(structTypes);
+        builder.unions(structTypes);
+        builder.exceptions(structTypes);
+        builder.enums(enumTypes);
+        builder.constants(constants);
+        builder.typedefs(typedefs);
+        builder.services(services);
+        Schema builtSchema = builder.build();
+
+        assertEquals(builtSchema.structs(), structTypes);
+        assertEquals(builtSchema.unions(), structTypes);
+        assertEquals(builtSchema.exceptions(), structTypes);
+        assertEquals(builtSchema.enums(), enumTypes);
+        assertEquals(builtSchema.constants(), constants);
+        assertEquals(builtSchema.typedefs(), typedefs);
+        assertEquals(builtSchema.services(), services);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectSchema() {
+        assertEquals(schema.toBuilder().build(), schema);
+    }
+}

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceMethodTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceMethodTest.java
@@ -1,0 +1,51 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.thrifty.schema.parser.FieldElement;
+import com.microsoft.thrifty.schema.parser.FunctionElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceMethodTest {
+    @Mock FunctionElement functionElement;
+    @Mock FieldNamingPolicy fieldNamingPolicy;
+
+    ServiceMethod serviceMethod;
+
+    @Before
+    public void setup() {
+        when(functionElement.params()).thenReturn(ImmutableList.<FieldElement>of());
+        when(functionElement.exceptions()).thenReturn(ImmutableList.<FieldElement>of());
+        serviceMethod = new ServiceMethod(functionElement, fieldNamingPolicy);
+    }
+
+    @Test
+    public void builderCreatesCorrectServiceMethod() {
+        ImmutableList<Field> fields = ImmutableList.of();
+        ImmutableMap<String, String> annotations = ImmutableMap.of();
+
+        ServiceMethod builderServiceMethod = serviceMethod.toBuilder()
+                .paramTypes(fields)
+                .exceptionTypes(fields)
+                .annotations(annotations)
+                .build();
+
+        assertEquals(builderServiceMethod.paramTypes(), fields);
+        assertEquals(builderServiceMethod.exceptionTypes(), fields);
+        assertEquals(builderServiceMethod.annotations(), annotations);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectServiceMethod() {
+        assertEquals(serviceMethod.toBuilder().build(), serviceMethod);
+    }
+}

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceTest.java
@@ -1,0 +1,61 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.thrifty.schema.parser.FunctionElement;
+import com.microsoft.thrifty.schema.parser.ServiceElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceTest {
+    @Mock ServiceElement serviceElement;
+    @Mock ThriftType thriftType;
+    @Mock Map<NamespaceScope, String> namespaces;
+    @Mock FieldNamingPolicy fieldNamingPolicy;
+
+    Service service;
+
+    @Before
+    public void setup() {
+        when(serviceElement.name()).thenReturn("name");
+        when(serviceElement.functions()).thenReturn(ImmutableList.<FunctionElement>of());
+        service = new Service(serviceElement, thriftType, namespaces, fieldNamingPolicy);
+    }
+
+    @Test
+    public void builderCreatesCorrectService() {
+        ImmutableList<ServiceMethod> methods = ImmutableList.of();
+        ThriftType type = mock(ThriftType.class);
+        ImmutableMap<String, String> annotations = ImmutableMap.of();
+        Map<NamespaceScope, String> namespaces = new HashMap<>();
+
+        Service builderService = service.toBuilder()
+                .methods(methods)
+                .type(type)
+                .annotations(annotations)
+                .namespaces(namespaces)
+                .build();
+
+        assertEquals(methods, builderService.methods());
+        assertEquals(type, builderService.type());
+        assertEquals(annotations, builderService.annotations());
+        assertEquals(namespaces, builderService.namespaces());
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectService() {
+        assertEquals(service.toBuilder().build(), service);
+    }
+}

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/StructTypeTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/StructTypeTest.java
@@ -1,0 +1,61 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.thrifty.schema.parser.FieldElement;
+import com.microsoft.thrifty.schema.parser.StructElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StructTypeTest {
+    @Mock StructElement element;
+    @Mock ThriftType thriftType;
+    @Mock Map<NamespaceScope, String> namespaces;
+    @Mock FieldNamingPolicy fieldNamingPolicy;
+
+    StructType structType;
+
+    @Before
+    public void setup() {
+        when(element.name()).thenReturn("name");
+        when(element.fields()).thenReturn(ImmutableList.<FieldElement>of());
+
+        structType = new StructType(element, thriftType, namespaces, fieldNamingPolicy);
+    }
+
+    @Test
+    public void builderCreatesCorrectStructType() {
+        ThriftType thriftType = mock(ThriftType.class);
+        ImmutableList<Field> fields = mock(ImmutableList.class);
+        ImmutableMap<NamespaceScope, String> namespaces = mock(ImmutableMap.class);
+        ImmutableMap<String, String> annotations = mock(ImmutableMap.class);
+
+        StructType builderStructType = structType.toBuilder()
+                .type(thriftType)
+                .fields(fields)
+                .annotations(annotations)
+                .namespaces(namespaces)
+                .build();
+
+        assertEquals(builderStructType.type(), thriftType);
+        assertEquals(builderStructType.fields(), fields);
+        assertEquals(builderStructType.namespaces(), namespaces);
+        assertEquals(builderStructType.annotations(), annotations);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectStructType() {
+        assertEquals(structType.toBuilder().build(), structType);
+    }
+}

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/TypedefTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/TypedefTest.java
@@ -1,0 +1,49 @@
+package com.microsoft.thrifty.schema;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.thrifty.schema.parser.TypedefElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TypedefTest {
+    @Mock TypedefElement element;
+    @Mock Map<NamespaceScope, String> namespaces;
+
+    Typedef typedef;
+
+    @Before
+    public void setup() {
+        when(element.newName()).thenReturn("name");
+        typedef = new Typedef(element, namespaces);
+    }
+
+    @Test
+    public void builderCreatesCorrectTypedef() {
+        ImmutableMap<String, String> annotations = ImmutableMap.of();
+        Map<NamespaceScope, String> namespace = mock(Map.class);
+
+        Typedef typedef = this.typedef.toBuilder()
+                .annotations(annotations)
+                .namespaces(namespace)
+                .build();
+
+        assertEquals(typedef.annotations(), annotations);
+        assertEquals(typedef.namespaces(), namespace);
+    }
+
+    @Test
+    public void toBuilderCreatesCorrectTypedef() {
+        assertEquals(typedef.toBuilder().build(), typedef);
+    }
+}


### PR DESCRIPTION
Adds `toBuilder()` API to schema components . This allows for creating custom instances of `Schema` components while respecting the original `Schema`'s immutability.

Overview of Changes:

`toBuilder()`
- Takes an instance of a class, returns a builder populated with the class’s fields

Builder Classes
- Added to each of the classes that are a field in `Schema`
- Builder is not publicly constructible, can only create a new one from an existing component instance

Putting this up to get feedback now. Happy to iterate on documentation and API surface area as needed. 

Big thanks to @hzsweers for thinking this up and helping implement it.