### PR TITLE
Name is state altering, remove it from hashcode.

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -237,7 +237,6 @@ public final class Field {
         result = 31 * result + (fieldNamingPolicy != null ? fieldNamingPolicy.hashCode() : 0);
         result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
         result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (javaName != null ? javaName.hashCode() : 0);
         return result;
     }
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -224,10 +224,7 @@ public final class Field {
         if (annotations != null ? !annotations.equals(field.annotations) : field.annotations != null) {
             return false;
         }
-        if (type != null ? !type.equals(field.type) : field.type != null) {
-            return false;
-        }
-        return javaName != null ? javaName.equals(field.javaName) : field.javaName == null;
+        return type != null ? type.equals(field.type) : field.type == null;
 
     }
 


### PR DESCRIPTION
Calling `name()` alters the `javaName` property. Remove this property from `hashcode()`.

Noticed this while bumping our model library onto the latest Thrifty. We're consuming Builders from #61 :)

cc @hzsweers
