### PR TITLE
Remove typedef assertions from TypeResolver

### DIFF
--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/TypeResolver.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/TypeResolver.java
@@ -173,7 +173,7 @@ final class TypeResolver {
 
         @Override
         public TypeName visitTypedef(ThriftType.TypedefType typedefType) {
-            throw new AssertionError("Typedefs should have been resolved");
+            return typedefType.originalType().accept(this);
         }
     };
 
@@ -254,7 +254,7 @@ final class TypeResolver {
 
         @Override
         public Byte visitTypedef(ThriftType.TypedefType typedefType) {
-            throw new AssertionError("Typedefs should have been resolved");
+            return typedefType.originalType().accept(this);
         }
     };
 }


### PR DESCRIPTION
I didn't end up seeing much of an upside to the assertions in TypeResolver; although it ultimately is an internal (package-private) class, it seems to me now that we were embedding too many assumptions about the caller's context there.

For both cases, we'll just do the "right" thing with typedefs.

Fixes #68