### PR TITLE
Fix builders by including Nullable fields contained in equals().

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -21,6 +21,7 @@
 package com.microsoft.thrifty.schema;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.microsoft.thrifty.schema.parser.ConstElement;
 import com.microsoft.thrifty.schema.parser.ConstValueElement;
 
@@ -140,7 +141,11 @@ public class Constant extends Named {
         }
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
-            this.namespaces = namespaces;
+            Map<NamespaceScope, String> immutableNamespaces = namespaces;
+            if (!(immutableNamespaces instanceof ImmutableMap)) {
+                immutableNamespaces = ImmutableMap.copyOf(namespaces);
+            }
+            this.namespaces = immutableNamespaces;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -196,7 +196,11 @@ public class EnumType extends Named {
         }
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
-            this.namespaces = namespaces;
+            Map<NamespaceScope, String> immutableNamespaces = namespaces;
+            if (!(immutableNamespaces instanceof ImmutableMap)) {
+                immutableNamespaces = ImmutableMap.copyOf(namespaces);
+            }
+            this.namespaces = immutableNamespaces;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -54,6 +54,7 @@ public final class Field {
         this.fieldNamingPolicy = builder.fieldNamingPolicy;
         this.annotations = builder.annotations;
         this.type = builder.type;
+        this.javaName = builder.javaName;
     }
 
     public Location location() {
@@ -128,7 +129,7 @@ public final class Field {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, fieldNamingPolicy, annotations, type);
+        return new Builder(element, fieldNamingPolicy, annotations, type, javaName);
     }
 
     public static final class Builder {
@@ -136,15 +137,18 @@ public final class Field {
         private FieldNamingPolicy fieldNamingPolicy;
         private ImmutableMap<String, String> annotations;
         private ThriftType type;
+        private String javaName;
 
         Builder(FieldElement element,
                        FieldNamingPolicy fieldNamingPolicy,
                        ImmutableMap<String, String> annotations,
-                       ThriftType type) {
+                       ThriftType type,
+                       String javaName) {
             this.element = element;
             this.fieldNamingPolicy = fieldNamingPolicy;
             this.annotations = annotations;
             this.type = type;
+            this.javaName = javaName;
         }
 
         public Builder element(FieldElement element) {
@@ -167,6 +171,11 @@ public final class Field {
 
         public Builder type(ThriftType type) {
             this.type = type;
+            return this;
+        }
+
+        public Builder javaName(String javaName) {
+            this.javaName = javaName;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -35,7 +35,7 @@ public final class Field {
     private final ImmutableMap<String, String> annotations;
     private ThriftType type;
 
-    private String javaName;
+    private transient String javaName;
 
     Field(FieldElement element, FieldNamingPolicy fieldNamingPolicy) {
         this.element = element;
@@ -54,7 +54,6 @@ public final class Field {
         this.fieldNamingPolicy = builder.fieldNamingPolicy;
         this.annotations = builder.annotations;
         this.type = builder.type;
-        this.javaName = builder.javaName;
     }
 
     public Location location() {
@@ -129,7 +128,7 @@ public final class Field {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, fieldNamingPolicy, annotations, type, javaName);
+        return new Builder(element, fieldNamingPolicy, annotations, type);
     }
 
     public static final class Builder {
@@ -137,18 +136,15 @@ public final class Field {
         private FieldNamingPolicy fieldNamingPolicy;
         private ImmutableMap<String, String> annotations;
         private ThriftType type;
-        private String javaName;
 
         Builder(FieldElement element,
                        FieldNamingPolicy fieldNamingPolicy,
                        ImmutableMap<String, String> annotations,
-                       ThriftType type,
-                       String javaName) {
+                       ThriftType type) {
             this.element = element;
             this.fieldNamingPolicy = fieldNamingPolicy;
             this.annotations = annotations;
             this.type = type;
-            this.javaName = javaName;
         }
 
         public Builder element(FieldElement element) {
@@ -171,17 +167,6 @@ public final class Field {
 
         public Builder type(ThriftType type) {
             this.type = type;
-            return this;
-        }
-
-        /**
-         * This field is transient and will be removed as part of https://github.com/Microsoft/thrifty/issues/69.
-         *
-         * @param javaName the javaName computed from the thrift name and naming policy.
-         * @return the javaName.
-         */
-        public Builder javaName(String javaName) {
-            this.javaName = javaName;
             return this;
         }
 
@@ -240,7 +225,6 @@ public final class Field {
             return false;
         }
         return type != null ? type.equals(field.type) : field.type == null;
-
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -174,6 +174,12 @@ public final class Field {
             return this;
         }
 
+        /**
+         * This field is transient and will be removed as part of https://github.com/Microsoft/thrifty/issues/69.
+         *
+         * @param javaName the javaName computed from the thrift name and naming policy.
+         * @return the javaName.
+         */
         public Builder javaName(String javaName) {
             this.javaName = javaName;
             return this;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -70,6 +70,7 @@ public final class Service extends Named {
         this.methods = builder.methods;
         this.type = builder.type;
         this.annotations = builder.annotations;
+        this.extendsService = builder.extendsService;
     }
 
     @Override
@@ -99,7 +100,7 @@ public final class Service extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, methods, type, annotations, namespaces());
+        return new Builder(element, methods, type, annotations, namespaces(), extendsService);
     }
 
     public static final class Builder {
@@ -108,17 +109,20 @@ public final class Service extends Named {
         private ThriftType type;
         private ImmutableMap<String, String> annotations;
         private Map<NamespaceScope, String> namespaces;
+        private ThriftType extendsService;
 
         Builder(ServiceElement element,
                ImmutableList<ServiceMethod> methods,
                ThriftType type,
                ImmutableMap<String, String> annotations,
-                Map<NamespaceScope, String> namespaces) {
+               Map<NamespaceScope, String> namespaces,
+               ThriftType extendsService) {
             this.element = element;
             this.methods = methods;
             this.type = type;
             this.annotations = annotations;
             this.namespaces = namespaces;
+            this.extendsService = extendsService;
         }
 
         public Builder element(ServiceElement element) {
@@ -149,6 +153,11 @@ public final class Service extends Named {
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
+            return this;
+        }
+
+        public Builder extendsService(ThriftType extendsService) {
+            this.extendsService = extendsService;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Service.java
@@ -152,7 +152,11 @@ public final class Service extends Named {
         }
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
-            this.namespaces = namespaces;
+            Map<NamespaceScope, String> immutableNamespaces = namespaces;
+            if (!(immutableNamespaces instanceof ImmutableMap)) {
+                immutableNamespaces = ImmutableMap.copyOf(namespaces);
+            }
+            this.namespaces = immutableNamespaces;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -66,6 +66,7 @@ public final class ServiceMethod {
         this.paramTypes = builder.paramTypes;
         this.exceptionTypes = builder.exceptionTypes;
         this.annotations = builder.annotations;
+        this.returnType = builder.returnType;
     }
 
     public Location location() {
@@ -105,7 +106,7 @@ public final class ServiceMethod {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, paramTypes, exceptionTypes, annotations);
+        return new Builder(element, paramTypes, exceptionTypes, annotations, returnType);
     }
 
     public static final class Builder {
@@ -113,15 +114,18 @@ public final class ServiceMethod {
         private ImmutableList<Field> paramTypes;
         private ImmutableList<Field> exceptionTypes;
         private ImmutableMap<String, String> annotations;
+        private ThriftType returnType;
 
         Builder(FunctionElement element,
                        ImmutableList<Field> paramTypes,
                        ImmutableList<Field> exceptionTypes,
-                       ImmutableMap<String, String> annotations) {
+                       ImmutableMap<String, String> annotations,
+                       ThriftType thriftType) {
             this.element = element;
             this.paramTypes = paramTypes;
             this.exceptionTypes = exceptionTypes;
             this.annotations = annotations;
+            this.returnType = thriftType;
         }
 
         public Builder element(FunctionElement element) {
@@ -144,6 +148,11 @@ public final class ServiceMethod {
 
         public Builder annotations(ImmutableMap<String, String> annotations) {
             this.annotations = annotations;
+            return this;
+        }
+
+        public Builder returnType(ThriftType returnType) {
+            this.returnType = returnType;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -148,7 +148,11 @@ public class StructType extends Named {
         }
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
-            this.namespaces = namespaces;
+            Map<NamespaceScope, String> immutableNamespaces = namespaces;
+            if (!(immutableNamespaces instanceof ImmutableMap)) {
+                immutableNamespaces = ImmutableMap.copyOf(namespaces);
+            }
+            this.namespaces = immutableNamespaces;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -47,6 +47,8 @@ public final class Typedef extends Named {
     private Typedef(Builder builder) {
         super(builder.element.newName(), builder.namespaces);
         this.element = builder.element;
+        this.oldType = builder.oldType;
+        this.type = builder.type;
         this.annotations = builder.annotations;
     }
 
@@ -82,7 +84,7 @@ public final class Typedef extends Named {
     }
 
     public Builder toBuilder() {
-        return new Builder(element, annotations, namespaces());
+        return new Builder(element, annotations, oldType, type, namespaces());
     }
 
     boolean link(Linker linker) {
@@ -127,13 +129,19 @@ public final class Typedef extends Named {
     public static final class Builder {
         private TypedefElement element;
         private ImmutableMap<String, String> annotations;
+        private ThriftType oldType;
+        private ThriftType type;
         private Map<NamespaceScope, String> namespaces;
 
         Builder(TypedefElement element,
                        ImmutableMap<String, String> annotations,
+                       ThriftType oldType,
+                       ThriftType type,
                        Map<NamespaceScope, String> namespaces) {
             this.element = element;
             this.annotations = annotations;
+            this.type = type;
+            this.oldType = oldType;
             this.namespaces = namespaces;
         }
 
@@ -152,6 +160,16 @@ public final class Typedef extends Named {
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
             this.namespaces = namespaces;
+            return this;
+        }
+
+        public Builder type(ThriftType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder oldType(ThriftType oldType) {
+            this.oldType = oldType;
             return this;
         }
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Typedef.java
@@ -159,7 +159,11 @@ public final class Typedef extends Named {
         }
 
         public Builder namespaces(Map<NamespaceScope, String> namespaces) {
-            this.namespaces = namespaces;
+            Map<NamespaceScope, String> immutableNamespaces = namespaces;
+            if (!(immutableNamespaces instanceof ImmutableMap)) {
+                immutableNamespaces = ImmutableMap.copyOf(namespaces);
+            }
+            this.namespaces = immutableNamespaces;
             return this;
         }
 

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceMethodTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceMethodTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -32,14 +33,17 @@ public class ServiceMethodTest {
     public void builderCreatesCorrectServiceMethod() {
         ImmutableList<Field> fields = ImmutableList.of();
         ImmutableMap<String, String> annotations = ImmutableMap.of();
+        ThriftType thriftType = mock(ThriftType.class);
 
         ServiceMethod builderServiceMethod = serviceMethod.toBuilder()
                 .paramTypes(fields)
                 .exceptionTypes(fields)
                 .annotations(annotations)
+                .returnType(thriftType)
                 .build();
 
         assertEquals(builderServiceMethod.paramTypes(), fields);
+        assertEquals(builderServiceMethod.returnType(), thriftType);
         assertEquals(builderServiceMethod.exceptionTypes(), fields);
         assertEquals(builderServiceMethod.annotations(), annotations);
     }

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/ServiceTest.java
@@ -46,10 +46,12 @@ public class ServiceTest {
                 .type(type)
                 .annotations(annotations)
                 .namespaces(namespaces)
+                .extendsService(type)
                 .build();
 
         assertEquals(methods, builderService.methods());
         assertEquals(type, builderService.type());
+        assertEquals(type, builderService.extendsService());
         assertEquals(annotations, builderService.annotations());
         assertEquals(namespaces, builderService.namespaces());
     }

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/TypedefTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/TypedefTest.java
@@ -32,13 +32,16 @@ public class TypedefTest {
     public void builderCreatesCorrectTypedef() {
         ImmutableMap<String, String> annotations = ImmutableMap.of();
         Map<NamespaceScope, String> namespace = mock(Map.class);
+        ThriftType oldType = mock(ThriftType.class);
 
         Typedef typedef = this.typedef.toBuilder()
                 .annotations(annotations)
                 .namespaces(namespace)
+                .oldType(oldType)
                 .build();
 
         assertEquals(typedef.annotations(), annotations);
+        assertEquals(typedef.oldType(), oldType);
         assertEquals(typedef.namespaces(), namespace);
     }
 


### PR DESCRIPTION
This pull request adds fields to builders that are present in equals(). Updated unit tests to assert fields added to Builders. Thanks to Zac for pointing this out. 

Zac also mentioned all namespace builders are taking Map instead of ImmutableMap. They should either take ImmutableMap or make a defensive copy. Ben, is there a preference here?