### PR TITLE
Replace trivial list transformations with streams

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumType.java
@@ -23,7 +23,6 @@ package com.microsoft.thrifty.schema;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.schema.parser.EnumElement;
-import com.microsoft.thrifty.schema.parser.EnumMemberElement;
 
 import java.util.List;
 import java.util.Map;
@@ -38,11 +37,9 @@ public class EnumType extends UserType {
     EnumType(Program program, EnumElement element) {
         super(program, new UserElementMixin(element));
 
-        ImmutableList.Builder<EnumMember> builder = ImmutableList.builder();
-        for (EnumMemberElement memberElement : element.members()) {
-            builder.add(new EnumMember(memberElement));
-        }
-        this.members = builder.build();
+        this.members = element.members().stream()
+                .map(EnumMember::new)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private EnumType(Builder builder) {
@@ -55,21 +52,17 @@ public class EnumType extends UserType {
     }
 
     public EnumMember findMemberByName(String name) {
-        for (EnumMember member : members) {
-            if (member.name().equals(name)) {
-                return member;
-            }
-        }
-        throw new NoSuchElementException();
+        return members.stream()
+                .filter(member -> member.name().equals(name))
+                .findFirst()
+                .orElseThrow(NoSuchElementException::new);
     }
 
     public EnumMember findMemberById(int id) {
-        for (EnumMember member : members) {
-            if (member.value() == id) {
-                return member;
-            }
-        }
-        throw new NoSuchElementException();
+        return members.stream()
+                .filter(member -> member.value() == id)
+                .findFirst()
+                .orElseThrow(NoSuchElementException::new);
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Linker.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 
@@ -447,14 +448,12 @@ class Linker {
                 String includeName = symbol.substring(0, ix);
                 String qualifiedName = symbol.substring(ix + 1);
                 String expectedPath = includeName + ".thrift";
-                for (Program includedProgram : program.includes()) {
-                    if (includedProgram.location().path().equals(expectedPath)) {
-                        constant = includedProgram.constantMap().get(qualifiedName);
-                        if (constant != null) {
-                            break;
-                        }
-                    }
-                }
+                constant = program.includes().stream()
+                        .filter(p -> p.location().path().equals(expectedPath))
+                        .map(p -> p.constantMap().get(qualifiedName))
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
             }
         }
         return constant;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -22,7 +22,6 @@ package com.microsoft.thrifty.schema;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.microsoft.thrifty.schema.parser.FieldElement;
 import com.microsoft.thrifty.schema.parser.FunctionElement;
 
 import java.util.LinkedHashMap;
@@ -41,17 +40,13 @@ public class ServiceMethod implements UserElement {
         this.mixin = new UserElementMixin(element);
         this.element = element;
 
-        ImmutableList.Builder<Field> paramsBuilder = ImmutableList.builder();
-        for (FieldElement parameter : element.params()) {
-            paramsBuilder.add(new Field(parameter));
-        }
-        this.parameters = paramsBuilder.build();
+        this.parameters = element.params().stream()
+                .map(Field::new)
+                .collect(ImmutableList.toImmutableList());
 
-        ImmutableList.Builder<Field> exceptionsBuilder = ImmutableList.builder();
-        for (FieldElement exception : element.exceptions()) {
-            exceptionsBuilder.add(new Field(exception));
-        }
-        this.exceptions = exceptionsBuilder.build();
+        this.exceptions = element.exceptions().stream()
+                .map(Field::new)
+                .collect(ImmutableList.toImmutableList());
     }
 
     protected ServiceMethod(Builder builder) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceType.java
@@ -22,7 +22,6 @@ package com.microsoft.thrifty.schema;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.microsoft.thrifty.schema.parser.FunctionElement;
 import com.microsoft.thrifty.schema.parser.ServiceElement;
 import com.microsoft.thrifty.schema.parser.TypeElement;
 
@@ -45,12 +44,9 @@ public class ServiceType extends UserType {
         super(program, new UserElementMixin(element));
 
         this.extendsServiceType = element.extendsService();
-
-        ImmutableList.Builder<ServiceMethod> methodListBuilder = ImmutableList.builder();
-        for (FunctionElement functionElement : element.functions()) {
-            methodListBuilder.add(new ServiceMethod(functionElement));
-        }
-        this.methods = methodListBuilder.build();
+        this.methods = element.functions().stream()
+                .map(ServiceMethod::new)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private ServiceType(Builder builder) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/StructType.java
@@ -22,7 +22,6 @@ package com.microsoft.thrifty.schema;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.microsoft.thrifty.schema.parser.FieldElement;
 import com.microsoft.thrifty.schema.parser.StructElement;
 
 import java.util.LinkedHashMap;
@@ -42,12 +41,9 @@ public class StructType extends UserType {
         super(program, new UserElementMixin(element));
 
         this.structType = element.type();
-
-        ImmutableList.Builder<Field> fieldsBuilder = ImmutableList.builder();
-        for (FieldElement fieldElement : element.fields()) {
-            fieldsBuilder.add(new Field(fieldElement));
-        }
-        this.fields = fieldsBuilder.build();
+        this.fields = element.fields().stream()
+                .map(Field::new)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private StructType(Builder builder) {


### PR DESCRIPTION
We can remove lots of intermediate collection-builders and simple
traversals with stream methods; the easy ones in thrifty-schema are
done here.