### PR TITLE
Use Path instead of Strings and Files

### DIFF
--- a/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
+++ b/thrifty-compiler/src/main/java/com/microsoft/thrifty/compiler/ThriftyCompiler.java
@@ -27,8 +27,9 @@ import com.microsoft.thrifty.schema.LoadFailedException;
 import com.microsoft.thrifty.schema.Loader;
 import com.microsoft.thrifty.schema.Schema;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,9 +79,9 @@ public class ThriftyCompiler {
     private static final String PARCELABLE_ARG = "--parcelable";
     private static final String JAVA_NAMES_ARG = "--use-java-style-names";
 
-    private File outputDirectory;
-    private List<String> thriftFiles = new ArrayList<>();
-    private List<String> searchPath = new ArrayList<>();
+    private Path outputDirectory;
+    private List<Path> thriftFiles = new ArrayList<>();
+    private List<Path> searchPath = new ArrayList<>();
     private String listTypeName;
     private String setTypeName;
     private String mapTypeName;
@@ -91,7 +92,7 @@ public class ThriftyCompiler {
     public static void main(String[] args) {
         try {
             ThriftyCompiler compiler = withArgs(args);
-            compiler.searchPath.add(0, System.getProperty("user.dir"));
+            compiler.searchPath.add(0, Paths.get(System.getProperty("user.dir")));
             System.out.println(compiler.searchPath.get(0));
             compiler.compile();
         } catch (Exception e) {
@@ -107,7 +108,7 @@ public class ThriftyCompiler {
         for (String arg : args) {
             if (arg.startsWith(OUT_PREFIX)) {
                 String path = arg.substring(OUT_PREFIX.length());
-                compiler.setOutputDirectory(new File(path));
+                compiler.setOutputDirectory(Paths.get(path));
             } else if (arg.startsWith(PATH_PREFIX)) {
                 String dirname = arg.substring(PATH_PREFIX.length());
                 compiler.addSearchDirectory(dirname);
@@ -141,12 +142,12 @@ public class ThriftyCompiler {
     }
 
     public ThriftyCompiler addThriftFile(String path) {
-        thriftFiles.add(path);
+        thriftFiles.add(Paths.get(path));
         return this;
     }
 
     public ThriftyCompiler addSearchDirectory(String path) {
-        searchPath.add(path);
+        searchPath.add(Paths.get(path));
         return this;
     }
 
@@ -165,19 +166,19 @@ public class ThriftyCompiler {
         return this;
     }
 
-    public ThriftyCompiler setOutputDirectory(File directory) {
+    public ThriftyCompiler setOutputDirectory(Path directory) {
         outputDirectory = directory;
         return this;
     }
 
     public void compile() throws IOException {
         Loader loader = new Loader();
-        for (String thriftFile : thriftFiles) {
+        for (Path thriftFile : thriftFiles) {
             loader.addThriftFile(thriftFile);
         }
 
-        for (String dir : searchPath) {
-            loader.addIncludePath(new File(dir));
+        for (Path dir : searchPath) {
+            loader.addIncludePath(dir);
         }
 
         Schema schema;

--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
@@ -70,6 +70,7 @@ import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -170,6 +171,17 @@ public final class ThriftyCodeGenerator {
     public ThriftyCodeGenerator usingTypeProcessor(TypeProcessor typeProcessor) {
         this.typeProcessor = typeProcessor;
         return this;
+    }
+
+    public void generate(final Path directory) throws IOException {
+        generate(new FileWriter() {
+            @Override
+            public void write(@Nullable JavaFile file) throws IOException {
+                if (file != null) {
+                    file.writeTo(directory);
+                }
+            }
+        });
     }
 
     public void generate(final File directory) throws IOException {

--- a/thrifty-java-codegen/src/test/java/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.java
+++ b/thrifty-java-codegen/src/test/java/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.java
@@ -349,7 +349,7 @@ public class ThriftyCodeGeneratorTest {
         }
 
         Loader loader = new Loader();
-        loader.addThriftFile(file.getCanonicalPath());
+        loader.addThriftFile(file.toPath().toAbsolutePath().normalize());
 
         return loader.load();
     }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Location.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Location.java
@@ -19,6 +19,7 @@ package com.microsoft.thrifty.schema;
 import com.google.common.base.Preconditions;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 public final class Location {
     private final String base;
@@ -67,12 +68,8 @@ public final class Location {
      * @return the Thrift program name representing this file.
      */
     public String getProgramName() {
-        String name = path;
-        int separatorIndex = name.lastIndexOf(File.pathSeparatorChar);
-        if (separatorIndex != -1) {
-            name = name.substring(separatorIndex + 1);
-        }
-        int dotIndex = name.indexOf('.');
+        String name = Paths.get(path).getFileName().toString();
+        int dotIndex = name.lastIndexOf('.');
         if (dotIndex != -1) {
             name = name.substring(0, dotIndex);
         }


### PR DESCRIPTION
This change updates the Loader API to take Path for thrift files and
for include directories, instead of String and File.  The prior API is
now deprecated, and will be removed prior to 1.0.0.

The compiler and code-generator are updated to accommodate the new API.