### PR TITLE
Use 'java-library' plugin instead of 'java'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ allprojects {
 
     project.ext {
         libraries = [
+                guava: [
+                        'com.google.guava:guava:21.0'
+                ],
+
                 okio: [
                         'com.squareup.okio:okio:1.11.0'
                 ],
@@ -55,7 +59,7 @@ buildscript {
 }
 
 subprojects { sp ->
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'idea'
     apply plugin: 'checkstyle'
 

--- a/thrifty-compiler-plugins/build.gradle
+++ b/thrifty-compiler-plugins/build.gradle
@@ -19,6 +19,6 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 dependencies {
-    compile libraries.javaPoet
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    api libraries.javaPoet
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/thrifty-compiler/build.gradle
+++ b/thrifty-compiler/build.gradle
@@ -18,14 +18,10 @@
  *
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':thrifty-schema')
-    compile project(':thrifty-java-codegen')
-    compile project(':thrifty-compiler-plugins')
+    implementation project(':thrifty-schema')
+    implementation project(':thrifty-java-codegen')
+    implementation project(':thrifty-compiler-plugins')
 }
 
 sourceSets {
@@ -40,9 +36,9 @@ sourceSets {
 }
 
 jar {
-    from {
-        (configurations.runtime).collect() {
-            it.isDirectory() ? it : zipTree(it)
+    [configurations.default, configurations.runtime].each { config ->
+        from(config.collect { it.isDirectory() ? it : zipTree(it) }) {
+            exclude 'META-INF/services/*'
         }
     }
 

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -18,13 +18,15 @@
  *
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
+
 dependencies {
-    compile project(':thrifty-compiler')
+    implementation project(':thrifty-compiler')
 
-    testCompile project(':thrifty-runtime')
-    testCompile project(':thrifty-test-server')
+    testImplementation project(':thrifty-runtime')
+    testImplementation project(':thrifty-test-server')
+    testImplementation libraries.guava
 
-    testCompile 'junit:junit:4.11'
+    testImplementation 'junit:junit:4.11'
 }
 
 uploadArchives.enabled = false
@@ -36,8 +38,10 @@ sourceSets {
 }
 
 jar {
-    from(configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }) {
-        exclude 'META-INF/services/*'
+    [configurations.default].each { config ->
+        from(config.collect { it.isDirectory() ? it : zipTree(it) }) {
+            exclude 'META-INF/services/*'
+        }
     }
 
     manifest {

--- a/thrifty-java-codegen/build.gradle
+++ b/thrifty-java-codegen/build.gradle
@@ -21,15 +21,15 @@
 description = 'Converts Thrifty Schemas into Java source files'
 
 dependencies {
-    compile project(":thrifty-schema")
-    compile project(":thrifty-runtime")
-    compile project(":thrifty-compiler-plugins")
-    compile libraries.okio
-    compile libraries.javaPoet
+    api project(":thrifty-schema")
+    api project(":thrifty-compiler-plugins")
+    api libraries.okio
+    api libraries.javaPoet
 
-    compile 'joda-time:joda-time:2.9.1'
+    implementation project(':thrifty-runtime')
+    implementation 'joda-time:joda-time:2.9.1'
 
-    testCompile libraries.testing
+    testImplementation libraries.testing
 
-    testCompile 'com.google.testing.compile:compile-testing:0.9'
+    testImplementation 'com.google.testing.compile:compile-testing:0.9'
 }

--- a/thrifty-runtime/build.gradle
+++ b/thrifty-runtime/build.gradle
@@ -24,8 +24,7 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 dependencies {
-    compile libraries.okio
+    api libraries.okio
 
-    testCompile libraries.testing
-    testCompile project(':thrifty-compiler')
+    testImplementation libraries.testing
 }

--- a/thrifty-schema/build.gradle
+++ b/thrifty-schema/build.gradle
@@ -35,17 +35,15 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     antlr "org.antlr:antlr4:4.6"
-    compile "org.antlr:antlr4:4.6"
+    implementation "org.antlr:antlr4:4.6"
 
-    compile project(':thrifty-runtime')
+    implementation libraries.okio
 
-    compile 'com.google.code.findbugs:jsr305:3.0.1'
-    compile 'com.google.guava:guava:21.0'
+    api 'com.google.code.findbugs:jsr305:3.0.1'
+    api libraries.guava
 
     compileOnly 'com.google.auto.value:auto-value:1.3'
     apt 'com.google.auto.value:auto-value:1.3'
 
-    compile libraries.okio
-
-    testCompile libraries.testing
+    testImplementation libraries.testing
 }

--- a/thrifty-test-server/build.gradle
+++ b/thrifty-test-server/build.gradle
@@ -19,8 +19,8 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.11'
-    compile 'org.apache.thrift:libthrift:0.9.3'
+    api group: 'junit', name: 'junit', version: '4.12'
+    implementation 'org.apache.thrift:libthrift:0.9.3'
 }
 
 uploadArchives.enabled = false


### PR DESCRIPTION
This paves the way for Java 9 compatibility, and removes some
implementation details from consumers' compile-time classpaths.  This
may break said consumers.

Fixes #118