### PR TITLE
Adopt more-idiomatic Java 8

### DIFF
--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/FieldNamer.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/FieldNamer.java
@@ -34,12 +34,7 @@ class FieldNamer {
         this.namingPolicy = namingPolicy;
     }
 
-    public String getName(Field field) {
-        String name = nameCache.get(field);
-        if (name == null) {
-            name = namingPolicy.apply(field.name());
-            nameCache.put(field, name);
-        }
-        return name;
+    String getName(Field field) {
+        return nameCache.computeIfAbsent(field, k -> namingPolicy.apply(field.name()));
     }
 }

--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/GenerateReaderVisitor.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/GenerateReaderVisitor.java
@@ -67,7 +67,7 @@ class GenerateReaderVisitor implements ThriftType.Visitor<Void> {
         this.fieldType = fieldType;
     }
 
-    public void generate() {
+    void generate() {
         byte fieldTypeCode = resolver.getTypeCode(fieldType);
         if (fieldTypeCode == TType.ENUM) {
             // Enums are I32 on the wire

--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
@@ -174,34 +174,25 @@ public final class ThriftyCodeGenerator {
     }
 
     public void generate(final Path directory) throws IOException {
-        generate(new FileWriter() {
-            @Override
-            public void write(@Nullable JavaFile file) throws IOException {
-                if (file != null) {
-                    file.writeTo(directory);
-                }
+        generate(file -> {
+            if (file != null) {
+                file.writeTo(directory);
             }
         });
     }
 
     public void generate(final File directory) throws IOException {
-        generate(new FileWriter() {
-            @Override
-            public void write(JavaFile file) throws IOException {
-                if (file != null) {
-                    file.writeTo(directory);
-                }
+        generate(file -> {
+            if (file != null) {
+                file.writeTo(directory);
             }
         });
     }
 
     public void generate(final Appendable appendable) throws IOException {
-        generate(new FileWriter() {
-            @Override
-            public void write(JavaFile file) throws IOException {
-                if (file != null) {
-                    file.writeTo(appendable);
-                }
+        generate(file -> {
+            if (file != null) {
+                file.writeTo(appendable);
             }
         });
     }

--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/TypeResolver.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/TypeResolver.java
@@ -186,12 +186,7 @@ final class TypeResolver {
             }
 
             String key = packageName + "##" + userType.name();
-            ClassName cn = nameCache.get(key);
-            if (cn == null) {
-                cn = ClassName.get(packageName, userType.name());
-                nameCache.put(key, cn);
-            }
-            return cn;
+            return nameCache.computeIfAbsent(key, k -> ClassName.get(packageName, userType.name()));
         }
     };
 

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/protocol/CompactProtocol.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/protocol/CompactProtocol.java
@@ -571,20 +571,20 @@ public class CompactProtocol extends Protocol {
     }
 
     private static final class CompactTypes {
-        public static final byte BOOLEAN_TRUE   = 0x01;
-        public static final byte BOOLEAN_FALSE  = 0x02;
-        public static final byte BYTE           = 0x03;
-        public static final byte I16            = 0x04;
-        public static final byte I32            = 0x05;
-        public static final byte I64            = 0x06;
-        public static final byte DOUBLE         = 0x07;
-        public static final byte BINARY         = 0x08;
-        public static final byte LIST           = 0x09;
-        public static final byte SET            = 0x0A;
-        public static final byte MAP            = 0x0B;
-        public static final byte STRUCT         = 0x0C;
+        static final byte BOOLEAN_TRUE   = 0x01;
+        static final byte BOOLEAN_FALSE  = 0x02;
+        static final byte BYTE           = 0x03;
+        static final byte I16            = 0x04;
+        static final byte I32            = 0x05;
+        static final byte I64            = 0x06;
+        static final byte DOUBLE         = 0x07;
+        static final byte BINARY         = 0x08;
+        static final byte LIST           = 0x09;
+        static final byte SET            = 0x0A;
+        static final byte MAP            = 0x0B;
+        static final byte STRUCT         = 0x0C;
 
-        public static byte ttypeToCompact(byte typeId) {
+        static byte ttypeToCompact(byte typeId) {
             switch (typeId) {
                 case TType.STOP:   return TType.STOP;
                 case TType.VOID:   throw new IllegalArgumentException("Unexpected VOID type");
@@ -606,7 +606,7 @@ public class CompactProtocol extends Protocol {
             }
         }
 
-        public static byte compactToTtype(byte compactId) {
+        static byte compactToTtype(byte compactId) {
             switch (compactId) {
                 case TType.STOP:    return TType.STOP;
                 case BOOLEAN_TRUE:  return TType.BOOL;

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/BuiltinType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/BuiltinType.java
@@ -60,7 +60,7 @@ public class BuiltinType extends ThriftType {
     private ImmutableMap<String, String> annotations;
 
     BuiltinType(String name) {
-        this(name, ImmutableMap.<String, String>of());
+        this(name, ImmutableMap.of());
     }
 
     BuiltinType(String name, ImmutableMap<String, String> annotations) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ListType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ListType.java
@@ -33,7 +33,7 @@ public class ListType extends ThriftType {
     private final ImmutableMap<String, String> annotations;
 
     ListType(ThriftType elementType) {
-        this(elementType, ImmutableMap.<String, String>of());
+        this(elementType, ImmutableMap.of());
     }
 
     ListType(ThriftType elementType, ImmutableMap<String, String> annotations) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/MapType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/MapType.java
@@ -34,7 +34,7 @@ public class MapType extends ThriftType {
     private final ImmutableMap<String, String> annotations;
 
     MapType(ThriftType keyType, ThriftType valueType) {
-        this(keyType, valueType, ImmutableMap.<String, String>of());
+        this(keyType, valueType, ImmutableMap.of());
     }
 
     MapType(ThriftType keyType, ThriftType valueType, ImmutableMap<String, String> annotations) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/SetType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/SetType.java
@@ -33,7 +33,7 @@ public class SetType extends ThriftType {
     private final ImmutableMap<String, String> annotations;
 
     SetType(ThriftType elementType) {
-        this(elementType, ImmutableMap.<String, String>of());
+        this(elementType, ImmutableMap.of());
     }
 
     SetType(ThriftType elementType, ImmutableMap<String, String> annotations) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
@@ -35,8 +35,8 @@ public abstract class FunctionElement {
                 .location(location)
                 .documentation("")
                 .oneWay(false)
-                .params(ImmutableList.<FieldElement>of())
-                .exceptions(ImmutableList.<FieldElement>of());
+                .params(ImmutableList.of())
+                .exceptions(ImmutableList.of());
     }
 
     public static Builder builder(FunctionElement element) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
@@ -43,7 +43,7 @@ public abstract class ServiceElement {
         return new AutoValue_ServiceElement.Builder()
                 .location(location)
                 .documentation("")
-                .functions(ImmutableList.<FunctionElement>of());
+                .functions(ImmutableList.of());
     }
 
     @AutoValue.Builder

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftFileElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftFileElement.java
@@ -42,15 +42,15 @@ public abstract class ThriftFileElement {
     public static Builder builder(Location location) {
         return new AutoValue_ThriftFileElement.Builder()
                 .location(location)
-                .namespaces(ImmutableList.<NamespaceElement>of())
-                .includes(ImmutableList.<IncludeElement>of())
-                .constants(ImmutableList.<ConstElement>of())
-                .typedefs(ImmutableList.<TypedefElement>of())
-                .enums(ImmutableList.<EnumElement>of())
-                .structs(ImmutableList.<StructElement>of())
-                .unions(ImmutableList.<StructElement>of())
-                .exceptions(ImmutableList.<StructElement>of())
-                .services(ImmutableList.<ServiceElement>of());
+                .namespaces(ImmutableList.of())
+                .includes(ImmutableList.of())
+                .constants(ImmutableList.of())
+                .typedefs(ImmutableList.of())
+                .enums(ImmutableList.of())
+                .structs(ImmutableList.of())
+                .unions(ImmutableList.of())
+                .exceptions(ImmutableList.of())
+                .services(ImmutableList.of());
     }
 
     ThriftFileElement() { }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftListener.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftListener.java
@@ -68,15 +68,15 @@ class ThriftListener extends AntlrThriftBaseListener {
     // We can do this with a bitset tracking token indices of trailing-comment tokens.
     private final BitSet trailingDocTokenIndexes = new BitSet(INITIAL_BITSET_CAPACITY);
 
-    private final List<IncludeElement> includes = new ArrayList<>();
+    private final List<IncludeElement>   includes   = new ArrayList<>();
     private final List<NamespaceElement> namespaces = new ArrayList<>();
-    private final List<EnumElement> enums = new ArrayList<>();
-    private final List<TypedefElement> typedefs = new ArrayList<>();
-    private final List<StructElement> structs = new ArrayList<>();
-    private final List<StructElement> unions = new ArrayList<>();
-    private final List<StructElement> exceptions = new ArrayList<>();
-    private final List<ConstElement> consts = new ArrayList<>();
-    private final List<ServiceElement> services = new ArrayList<>();
+    private final List<EnumElement>      enums      = new ArrayList<>();
+    private final List<TypedefElement>   typedefs   = new ArrayList<>();
+    private final List<StructElement>    structs    = new ArrayList<>();
+    private final List<StructElement>    unions     = new ArrayList<>();
+    private final List<StructElement>    exceptions = new ArrayList<>();
+    private final List<ConstElement>     consts     = new ArrayList<>();
+    private final List<ServiceElement>   services   = new ArrayList<>();
 
     /**
      * Creates a new ThriftListener instance.

--- a/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServer.java
+++ b/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServer.java
@@ -59,12 +59,9 @@ public class TestServer implements TestRule {
         server = startServer(processor, factory);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                latch.countDown();
-                server.serve();
-            }
+        serverThread = new Thread(() -> {
+            latch.countDown();
+            server.serve();
         });
 
         serverThread.start();


### PR DESCRIPTION
- Remove now-redundant type arguments
- Use new Map APIs like computeIfAbsent
- Use lambdas instead of anonymous Runnables