### PR TITLE
Improve reporting of duplicate-symbol errors

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Program.java
@@ -200,7 +200,7 @@ public class Program {
         for (UserType userType : allUserTypes()) {
             UserType oldValue = symbolMap.put(userType.name(), userType);
             if (oldValue != null) {
-                throw duplicateSymbol(userType.name(), oldValue, userType);
+                reportDuplicateSymbol(loader.errorReporter(), oldValue, userType);
             }
         }
 
@@ -210,17 +210,20 @@ public class Program {
         for (Constant constant : constants()) {
             Constant oldValue = constSymbolMap.put(constant.name(), constant);
             if (oldValue != null) {
-                throw duplicateSymbol(constant.name(), oldValue, constant);
+                reportDuplicateSymbol(loader.errorReporter(), oldValue, constant);
             }
         }
 
         this.constSymbols = ImmutableMap.copyOf(constSymbolMap);
     }
 
-    private IllegalStateException duplicateSymbol(String symbol, UserElement oldValue, UserElement newValue) {
-        throw new IllegalStateException(
-                "Duplicate symbols: '" + symbol + "' defined at "
-                + oldValue.location() + " and at " + newValue.location());
+    private void reportDuplicateSymbol(
+            ErrorReporter reporter,
+            UserElement oldValue,
+            UserElement newValue) {
+        String message = "Duplicate symbols: " + oldValue.name() + " defined at "
+                + oldValue.location() + " and at " + newValue.location();
+        reporter.error(newValue.location(), message);
     }
 
     @Override

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/LoaderTest.java
@@ -887,6 +887,44 @@ public class LoaderTest {
         }
     }
 
+    @Test
+    public void loadingProgramWithDuplicateSymbolsThrows() throws Exception {
+        String thrift = "" +
+                "namespace java duplicateSymbols;\n" +
+                "\n" +
+                "struct Foo {\n" +
+                "  1: required string foo;\n" +
+                "}\n" +
+                "\n" +
+                "enum Foo {\n" +
+                "  FOO\n" +
+                "}\n";
+
+        try {
+            load(thrift);
+            fail();
+        } catch (LoadFailedException expected) {
+            assertThat(expected, hasMessage(containsString("Duplicate symbols: Foo defined at")));
+        }
+    }
+
+    @Test
+    public void loadingProgramWithDuplicatedConstantNamesThrows() throws Exception {
+        String thrift = "" +
+                "namespace java duplicateConstants;\n" +
+                "\n" +
+                "const i32 Foo = 10 \n" +
+                "\n" +
+                "const string Foo = 'bar'\n";
+
+        try {
+            load(thrift);
+            fail();
+        } catch (LoadFailedException expected) {
+            assertThat(expected, hasMessage(containsString("Duplicate symbols: Foo defined at")));
+        }
+    }
+
     private Schema load(String thrift) throws Exception {
         File f = tempDir.newFile();
         writeTo(f, thrift);


### PR DESCRIPTION
The first installment of JaCoCo-directed testing has borne fruit!  It
turns out that:
a) we were not testing handling of duplicate symbols at all, and
b) our error-reporting was not good.

Now we use an ErrorReporter, and have tests.