### PR TITLE
Fix server error handling

### DIFF
--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
@@ -633,6 +633,7 @@ public final class ThriftyCodeGenerator {
                 .returns(typeResolver.getJavaClass(structType))
                 .addParameter(TypeNames.PROTOCOL, "protocol")
                 .addParameter(builderClassName, "builder")
+                .addException(TypeNames.THRIFT_EXCEPTION)
                 .addException(TypeNames.IO_EXCEPTION);
 
         final MethodSpec readHelper = MethodSpec.methodBuilder("read")
@@ -640,6 +641,7 @@ public final class ThriftyCodeGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(typeResolver.getJavaClass(structType))
                 .addParameter(TypeNames.PROTOCOL, "protocol")
+                .addException(TypeNames.THRIFT_EXCEPTION)
                 .addException(TypeNames.IO_EXCEPTION)
                 .addStatement("return read(protocol, new $T())", builderClassName)
                 .build();
@@ -730,7 +732,7 @@ public final class ThriftyCodeGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(Protocol.class, "protocol")
                 .addStatement("ADAPTER.write(protocol, this)")
-                .addException(IOException.class)
+                .addException(TypeNames.IO_EXCEPTION)
                 .build();
     }
 

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/Adapter.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/Adapter.java
@@ -38,7 +38,7 @@ public interface Adapter<T, B extends StructBuilder<T>> {
      * @return an instance of {@link T} populated with the data just read.
      * @throws IOException if reading fails, or if the struct is malformed.
      */
-    T read(Protocol protocol) throws IOException;
+    T read(Protocol protocol) throws ThriftException, IOException;
 
     /**
      * Reads a new instane of {@link T} from the given {@code protocol}, using
@@ -49,7 +49,7 @@ public interface Adapter<T, B extends StructBuilder<T>> {
      * @return an instance of {@link T} populated with the data just read.
      * @throws IOException if reading fails, or if the struct is malformed.
      */
-    T read(Protocol protocol, B builder) throws IOException;
+    T read(Protocol protocol, B builder) throws ThriftException, IOException;
 
     /**
      * Writes the given {@code struct} to the given {@code protocol}.

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/ThriftException.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/ThriftException.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Represents a Thrift protocol-level error.
  */
-public class ThriftException extends RuntimeException {
+public class ThriftException extends Exception {
     /**
      * Identifies kinds of protocol violation.
      */

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/AsyncClientBase.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/AsyncClientBase.java
@@ -21,6 +21,7 @@
 package com.microsoft.thrifty.service;
 
 import com.microsoft.thrifty.Struct;
+import com.microsoft.thrifty.ThriftException;
 import com.microsoft.thrifty.protocol.Protocol;
 
 import java.io.Closeable;
@@ -184,7 +185,7 @@ public class AsyncClientBase extends ClientBase implements Closeable {
             }
         }
 
-        private void invokeRequest() throws IOException, InterruptedException {
+        private void invokeRequest() throws ThriftException, IOException, InterruptedException {
             MethodCall<?> call = pendingCalls.take();
             if (!running.get()) {
                 if (call != null) {
@@ -201,16 +202,16 @@ public class AsyncClientBase extends ClientBase implements Closeable {
             Exception error = null;
             try {
                 result = AsyncClientBase.this.invokeRequest(call);
-            } catch (IOException | RuntimeException e) {
+            } catch (ThriftException | IOException | RuntimeException e) {
                 throw e;
-            } catch (UndeclaredServerException e) {
+            } catch (ServerException e) {
                 error = e.thriftException;
             } catch (Exception e) {
                 if (e instanceof Struct) {
                     error = e;
                 } else {
-                    // invokeRequest should only throw UndeclaredServerException, IOException,
-                    // RuntimeExceptions (like ThriftException) and the Struct Exception from MethodCall
+                    // invokeRequest should only throw one of the caught Exception types or
+                    // an Exception extending Struct from MethodCall
                     throw new AssertionError("Unexpected exception", e);
                 }
             }

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
@@ -69,7 +69,7 @@ public class ClientBase implements Closeable {
 
         try {
             return invokeRequest(methodCall);
-        } catch (UndeclaredServerException e) {
+        } catch (ServerException e) {
             throw e.thriftException;
         }
     }
@@ -100,8 +100,8 @@ public class ClientBase implements Closeable {
      *
      * @param call the remote method call to be invoked
      * @return the result of the method call
+     * @throws ServerException wrapper around {@link ThriftException}. Callers should catch and unwrap this.
      * @throws IOException from the protocol
-     * @throws UndeclaredServerException exception received from server that was not declared in schema
      * @throws Exception exception received from server implements {@link com.microsoft.thrifty.Struct}
      */
     final Object invokeRequest(MethodCall<?> call) throws Exception {
@@ -129,7 +129,7 @@ public class ClientBase implements Closeable {
         if (metadata.type == TMessageType.EXCEPTION) {
             ThriftException e = ThriftException.read(protocol);
             protocol.readMessageEnd();
-            throw new UndeclaredServerException(e);
+            throw new ServerException(e);
         } else if (metadata.type != TMessageType.REPLY) {
             throw new ThriftException(
                     ThriftException.Kind.INVALID_MESSAGE_TYPE,
@@ -152,10 +152,10 @@ public class ClientBase implements Closeable {
         return call.receive(protocol, metadata);
     }
 
-    static class UndeclaredServerException extends Exception {
+    static class ServerException extends Exception {
         final ThriftException thriftException;
 
-        UndeclaredServerException(ThriftException thriftException) {
+        ServerException(ThriftException thriftException) {
             this.thriftException = thriftException;
         }
     }

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
@@ -67,7 +67,11 @@ public class ClientBase implements Closeable {
             throw new IllegalStateException("Cannot write to a closed service client");
         }
 
-        return invokeRequest(methodCall);
+        try {
+            return invokeRequest(methodCall);
+        } catch (UndeclaredServerException e) {
+            throw e.thriftException;
+        }
     }
 
     /**
@@ -96,9 +100,8 @@ public class ClientBase implements Closeable {
      *
      * @param call the remote method call to be invoked
      * @return the result of the method call
-     * @throws AbortException thrown after {@link #handleExceptionMessage(MethodCall, ThriftException)} was called to
-     *   indicate that there is no further result or exception
      * @throws IOException from the protocol
+     * @throws UndeclaredServerException exception received from server that was not declared in schema
      * @throws Exception exception received from server implements {@link com.microsoft.thrifty.Struct}
      */
     final Object invokeRequest(MethodCall<?> call) throws Exception {
@@ -126,8 +129,7 @@ public class ClientBase implements Closeable {
         if (metadata.type == TMessageType.EXCEPTION) {
             ThriftException e = ThriftException.read(protocol);
             protocol.readMessageEnd();
-            handleExceptionMessage(call, e);
-            throw new AbortException();
+            throw new UndeclaredServerException(e);
         } else if (metadata.type != TMessageType.REPLY) {
             throw new ThriftException(
                     ThriftException.Kind.INVALID_MESSAGE_TYPE,
@@ -150,9 +152,11 @@ public class ClientBase implements Closeable {
         return call.receive(protocol, metadata);
     }
 
-    void handleExceptionMessage(MethodCall<?> call, ThriftException e) {
-        throw e;
-    }
+    static class UndeclaredServerException extends Exception {
+        final ThriftException thriftException;
 
-    static class AbortException extends Exception { }
+        UndeclaredServerException(ThriftException thriftException) {
+            this.thriftException = thriftException;
+        }
+    }
 }

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/Xtruct.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/Xtruct.java
@@ -23,6 +23,7 @@ package com.microsoft.thrifty.protocol;
 import com.microsoft.thrifty.Adapter;
 import com.microsoft.thrifty.StructBuilder;
 import com.microsoft.thrifty.TType;
+import com.microsoft.thrifty.ThriftException;
 import com.microsoft.thrifty.ThriftField;
 import com.microsoft.thrifty.util.ProtocolUtil;
 
@@ -216,7 +217,7 @@ public final class Xtruct {
         }
 
         @Override
-        public Xtruct read(Protocol protocol, Builder builder) throws IOException {
+        public Xtruct read(Protocol protocol, Builder builder) throws ThriftException, IOException {
             protocol.readStructBegin();
             while (true) {
                 FieldMetadata field = protocol.readFieldBegin();
@@ -280,7 +281,7 @@ public final class Xtruct {
         }
 
         @Override
-        public Xtruct read(Protocol protocol) throws IOException {
+        public Xtruct read(Protocol protocol) throws ThriftException, IOException {
             return read(protocol, new Builder());
         }
     }


### PR DESCRIPTION
The current implementation of `AsyncClientBase` will call success after for `TMessageType.EXCEPTION` exceptions. The simple fix would have been to return  when getting an `AbortException`, but I decided to streamline it a bit. Now fail and success are each only called in a single place and there is no separate exception handling anymore. 

