### PR TITLE
Add UUID to parsing for matching elements across instances

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Constant.java
@@ -27,6 +27,7 @@ import com.microsoft.thrifty.schema.parser.ConstValueElement;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -44,6 +45,7 @@ public class Constant implements UserElement {
         this.element = element;
         this.namespaces = namespaces;
         this.mixin = new UserElementMixin(
+                element.uuid(),
                 element.name(),
                 element.location(),
                 element.documentation(),
@@ -72,6 +74,11 @@ public class Constant implements UserElement {
             ns = namespaces.get(NamespaceScope.ALL);
         }
         return ns;
+    }
+
+    @Override
+    public UUID uuid() {
+        return mixin.uuid();
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumMember.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/EnumMember.java
@@ -24,6 +24,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.thrifty.schema.parser.EnumMemberElement;
 
+import java.util.UUID;
+
 /**
  * A named member of an {@link EnumType}.
  */
@@ -43,6 +45,11 @@ public class EnumMember implements UserElement {
 
     public int value() {
         return value;
+    }
+
+    @Override
+    public UUID uuid() {
+        return mixin.uuid();
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/Field.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import com.microsoft.thrifty.schema.parser.ConstValueElement;
 import com.microsoft.thrifty.schema.parser.FieldElement;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 public class Field implements UserElement {
@@ -80,6 +82,11 @@ public class Field implements UserElement {
             name = type.name();
         }
         return name;
+    }
+
+    @Override
+    public UUID uuid() {
+        return mixin.uuid();
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/ServiceMethod.java
@@ -27,6 +27,7 @@ import com.microsoft.thrifty.schema.parser.FunctionElement;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class ServiceMethod implements UserElement {
 
@@ -71,6 +72,11 @@ public class ServiceMethod implements UserElement {
 
     public boolean oneWay() {
         return element.oneWay();
+    }
+
+    @Override
+    public UUID uuid() {
+        return mixin.uuid();
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserElement.java
@@ -22,10 +22,21 @@ package com.microsoft.thrifty.schema;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.UUID;
+
 /**
  * Represents data common to user-defined elements of a Thrift program.
  */
 public interface UserElement {
+    /**
+     * A globally unique ID for this element. This is useful for cases where you newBuilder() an element to change it
+     * (such as in a Schema preprocessor) and want to update references from other objects in a deterministic way that
+     * matches IDs. If you want a new instance of an object that is unrelated, you should change this value.
+     *
+     * @return the uuid of this element.
+     */
+    UUID uuid();
+
     /**
      * Gets the name of the element.
      *

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserElementMixin.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserElementMixin.java
@@ -33,6 +33,7 @@ import com.microsoft.thrifty.schema.parser.TypedefElement;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -41,44 +42,48 @@ import javax.annotation.Nullable;
  * which does not conveniently fit in a single base class.
  */
 class UserElementMixin implements UserElement {
+    private final UUID uuid;
     private final String name;
     private final Location location;
     private final String documentation;
     private final ImmutableMap<String, String> annotations;
 
     UserElementMixin(StructElement struct) {
-        this(struct.name(), struct.location(), struct.documentation(), struct.annotations());
+        this(struct.uuid(), struct.name(), struct.location(), struct.documentation(), struct.annotations());
     }
 
     UserElementMixin(FieldElement field) {
-        this(field.name(), field.location(), field.documentation(), field.annotations());
+        this(field.uuid(), field.name(), field.location(), field.documentation(), field.annotations());
     }
 
     UserElementMixin(EnumElement enumElement) {
-        this(enumElement.name(), enumElement.location(), enumElement.documentation(), enumElement.annotations());
+        this(enumElement.uuid(), enumElement.name(), enumElement.location(), enumElement.documentation(),
+                enumElement.annotations());
     }
 
     UserElementMixin(EnumMemberElement member) {
-        this(member.name(), member.location(), member.documentation(), member.annotations());
+        this(member.uuid(), member.name(), member.location(), member.documentation(), member.annotations());
     }
 
     UserElementMixin(TypedefElement element) {
-        this(element.newName(), element.location(), element.documentation(), element.annotations());
+        this(element.uuid(), element.newName(), element.location(), element.documentation(), element.annotations());
     }
 
     UserElementMixin(ServiceElement element) {
-        this(element.name(), element.location(), element.documentation(), element.annotations());
+        this(element.uuid(), element.name(), element.location(), element.documentation(), element.annotations());
     }
 
     UserElementMixin(FunctionElement element) {
-        this(element.name(), element.location(), element.documentation(), element.annotations());
+        this(element.uuid(), element.name(), element.location(), element.documentation(), element.annotations());
     }
 
     UserElementMixin(
+            UUID uuid,
             String name,
             Location location,
             String documentation,
             @Nullable AnnotationElement annotationElement) {
+        this.uuid = uuid;
         this.name = name;
         this.location = location;
         this.documentation = documentation;
@@ -91,10 +96,16 @@ class UserElementMixin implements UserElement {
     }
 
     private UserElementMixin(Builder builder) {
+        this.uuid = builder.uuid;
         this.name = builder.name;
         this.location = builder.location;
         this.documentation = builder.documentation;
         this.annotations = builder.annotations;
+    }
+
+    @Override
+    public UUID uuid() {
+        return uuid;
     }
 
     @Override
@@ -144,7 +155,8 @@ class UserElementMixin implements UserElement {
     @Override
     public String toString() {
         return "UserElementMixin{"
-                + "name='" + name + '\''
+                + "uuid='" + uuid + '\''
+                + ", name='" + name + '\''
                 + ", location=" + location
                 + ", documentation='" + documentation + '\''
                 + ", annotations=" + annotations
@@ -158,6 +170,7 @@ class UserElementMixin implements UserElement {
 
         UserElementMixin that = (UserElementMixin) o;
 
+        if (!uuid.equals(that.uuid)) return false;
         if (!name.equals(that.name)) return false;
         if (!location.equals(that.location)) return false;
         if (!documentation.equals(that.documentation)) return false;
@@ -167,7 +180,8 @@ class UserElementMixin implements UserElement {
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
+        int result = uuid.hashCode();
+        result = 31 * result + name.hashCode();
         result = 31 * result + location.hashCode();
         result = 31 * result + documentation.hashCode();
         result = 31 * result + annotations.hashCode();
@@ -179,16 +193,23 @@ class UserElementMixin implements UserElement {
     }
 
     static class Builder {
+        private UUID uuid;
         private String name;
         private Location location;
         private String documentation;
         private ImmutableMap<String, String> annotations;
 
         private Builder(UserElement userElement) {
+            this.uuid = userElement.uuid();
             this.name = userElement.name();
             this.location = userElement.location();
             this.documentation = userElement.documentation();
             this.annotations = userElement.annotations();
+        }
+
+        Builder uuid(UUID uuid) {
+            this.uuid = Preconditions.checkNotNull(uuid, "uuid");
+            return this;
         }
 
         Builder name(String name) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserType.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/UserType.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Base type of all user-defined Thrift IDL types, including structs, unions,
@@ -60,6 +61,11 @@ public abstract class UserType extends ThriftType implements UserElement {
 
     public ImmutableMap<NamespaceScope, String> namespaces() {
         return namespaces;
+    }
+
+    @Override
+    public UUID uuid() {
+        return mixin.uuid();
     }
 
     @Override

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstElement.java
@@ -23,18 +23,22 @@ package com.microsoft.thrifty.schema.parser;
 import com.google.auto.value.AutoValue;
 import com.microsoft.thrifty.schema.Location;
 
+import java.util.UUID;
+
 @AutoValue
 public abstract class ConstElement {
     public abstract Location location();
     public abstract String documentation();
     public abstract TypeElement type();
     public abstract String name();
+    public abstract UUID uuid();
     public abstract ConstValueElement value();
 
     public static Builder builder(Location location) {
         return new AutoValue_ConstElement.Builder()
                 .location(location)
-                .documentation("");
+                .documentation("")
+                .uuid(UUID.randomUUID());
     }
 
     ConstElement() { }
@@ -45,6 +49,7 @@ public abstract class ConstElement {
         Builder documentation(String documentation);
         Builder type(TypeElement type);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder value(ConstValueElement value);
 
         ConstElement build();

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ConstElement.java
@@ -38,7 +38,7 @@ public abstract class ConstElement {
         return new AutoValue_ConstElement.Builder()
                 .location(location)
                 .documentation("")
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     ConstElement() { }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumElement.java
@@ -44,7 +44,7 @@ public abstract class EnumElement {
         return new AutoValue_EnumElement.Builder()
                 .location(location)
                 .documentation("")
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     @AutoValue.Builder

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumElement.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.schema.Location;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -33,6 +34,7 @@ public abstract class EnumElement {
     public abstract Location location();
     public abstract String documentation();
     public abstract String name();
+    public abstract UUID uuid();
     public abstract ImmutableList<EnumMemberElement> members();
     @Nullable public abstract AnnotationElement annotations();
 
@@ -41,7 +43,8 @@ public abstract class EnumElement {
     public static Builder builder(Location location) {
         return new AutoValue_EnumElement.Builder()
                 .location(location)
-                .documentation("");
+                .documentation("")
+                .uuid(UUID.randomUUID());
     }
 
     @AutoValue.Builder
@@ -49,6 +52,7 @@ public abstract class EnumElement {
         Builder location(Location location);
         Builder documentation(String documentation);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder members(List<EnumMemberElement> members);
         Builder annotations(AnnotationElement annotations);
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumMemberElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumMemberElement.java
@@ -23,6 +23,8 @@ package com.microsoft.thrifty.schema.parser;
 import com.google.auto.value.AutoValue;
 import com.microsoft.thrifty.schema.Location;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -30,13 +32,15 @@ public abstract class EnumMemberElement {
     public abstract Location location();
     public abstract String documentation();
     public abstract String name();
+    public abstract UUID uuid();
     public abstract int value();
     @Nullable public abstract AnnotationElement annotations();
 
     public static Builder builder(Location location) {
         return new AutoValue_EnumMemberElement.Builder()
                 .location(location)
-                .documentation("");
+                .documentation("")
+                .uuid(UUID.randomUUID());
     }
 
     EnumMemberElement() { }
@@ -46,6 +50,7 @@ public abstract class EnumMemberElement {
         Builder location(Location location);
         Builder documentation(String documentation);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder value(int value);
         Builder annotations(AnnotationElement annotations);
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumMemberElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/EnumMemberElement.java
@@ -40,7 +40,7 @@ public abstract class EnumMemberElement {
         return new AutoValue_EnumMemberElement.Builder()
                 .location(location)
                 .documentation("")
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     EnumMemberElement() { }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
@@ -24,6 +24,8 @@ import com.google.auto.value.AutoValue;
 import com.microsoft.thrifty.schema.Location;
 import com.microsoft.thrifty.schema.Requiredness;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -32,7 +34,8 @@ public abstract class FieldElement {
         return new AutoValue_FieldElement.Builder()
                 .location(location)
                 .documentation("")
-                .requiredness(Requiredness.DEFAULT);
+                .requiredness(Requiredness.DEFAULT)
+                .uuid(UUID.randomUUID());
     }
 
     public FieldElement withId(int fieldId) {
@@ -47,6 +50,7 @@ public abstract class FieldElement {
     public abstract Requiredness requiredness();
     public abstract TypeElement type();
     public abstract String name();
+    public abstract UUID uuid();
     @Nullable public abstract ConstValueElement constValue();
     @Nullable public abstract AnnotationElement annotations();
 
@@ -60,6 +64,7 @@ public abstract class FieldElement {
         Builder requiredness(Requiredness requiredness);
         Builder type(TypeElement type);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder constValue(ConstValueElement constValue);
         Builder annotations(AnnotationElement annotations);
 

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
@@ -35,7 +35,7 @@ public abstract class FieldElement {
                 .location(location)
                 .documentation("")
                 .requiredness(Requiredness.DEFAULT)
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     public FieldElement withId(int fieldId) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.schema.Location;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -36,7 +37,8 @@ public abstract class FunctionElement {
                 .documentation("")
                 .oneWay(false)
                 .params(ImmutableList.of())
-                .exceptions(ImmutableList.of());
+                .exceptions(ImmutableList.of())
+                .uuid(UUID.randomUUID());
     }
 
     public static Builder builder(FunctionElement element) {
@@ -48,6 +50,7 @@ public abstract class FunctionElement {
     public abstract boolean oneWay();
     public abstract TypeElement returnType();
     public abstract String name();
+    public abstract UUID uuid();
     public abstract ImmutableList<FieldElement> params();
     public abstract ImmutableList<FieldElement> exceptions();
     @Nullable public abstract AnnotationElement annotations();
@@ -61,6 +64,7 @@ public abstract class FunctionElement {
         Builder oneWay(boolean oneWay);
         Builder returnType(TypeElement returnType);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder params(List<FieldElement> params);
         Builder exceptions(List<FieldElement> params);
         Builder annotations(AnnotationElement annotations);

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
@@ -38,7 +38,7 @@ public abstract class FunctionElement {
                 .oneWay(false)
                 .params(ImmutableList.of())
                 .exceptions(ImmutableList.of())
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     public static Builder builder(FunctionElement element) {

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.schema.Location;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -33,6 +34,7 @@ public abstract class ServiceElement {
     public abstract Location location();
     public abstract String documentation();
     public abstract String name();
+    public abstract UUID uuid();
     @Nullable public abstract TypeElement extendsService();
     public abstract ImmutableList<FunctionElement> functions();
     @Nullable public abstract AnnotationElement annotations();
@@ -43,7 +45,8 @@ public abstract class ServiceElement {
         return new AutoValue_ServiceElement.Builder()
                 .location(location)
                 .documentation("")
-                .functions(ImmutableList.of());
+                .functions(ImmutableList.of())
+                .uuid(UUID.randomUUID());
     }
 
     @AutoValue.Builder
@@ -51,6 +54,7 @@ public abstract class ServiceElement {
         Builder location(Location location);
         Builder documentation(String documentation);
         Builder name(String name);
+        Builder uuid(UUID uuid);
         Builder extendsService(TypeElement serviceName);
         Builder functions(List<FunctionElement> functions);
         Builder annotations(AnnotationElement annotations);

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ServiceElement.java
@@ -46,7 +46,7 @@ public abstract class ServiceElement {
                 .location(location)
                 .documentation("")
                 .functions(ImmutableList.of())
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     @AutoValue.Builder

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/StructElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/StructElement.java
@@ -47,7 +47,7 @@ public abstract class StructElement {
         return new AutoValue_StructElement.Builder()
                 .location(location)
                 .documentation("")
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     StructElement() { }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/StructElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/StructElement.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.microsoft.thrifty.schema.Location;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -36,6 +37,7 @@ public abstract class StructElement {
     public abstract Location location();
     public abstract String documentation();
     public abstract Type type();
+    public abstract UUID uuid();
     public abstract String name();
     public abstract ImmutableList<FieldElement> fields();
     @Nullable
@@ -44,7 +46,8 @@ public abstract class StructElement {
     public static Builder builder(Location location) {
         return new AutoValue_StructElement.Builder()
                 .location(location)
-                .documentation("");
+                .documentation("")
+                .uuid(UUID.randomUUID());
     }
 
     StructElement() { }
@@ -54,6 +57,7 @@ public abstract class StructElement {
         Builder location(Location location);
         Builder documentation(String documentation);
         Builder type(Type type);
+        Builder uuid(UUID uuid);
         Builder name(String name);
         Builder fields(List<FieldElement> fields);
         Builder annotations(AnnotationElement annotations);

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftyParserPlugins.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/ThriftyParserPlugins.java
@@ -1,0 +1,72 @@
+package com.microsoft.thrifty.schema.parser;
+
+import java.util.UUID;
+
+/**
+ * Utility class to inject handlers to certain standard Thrifty operations.
+ */
+public final class ThriftyParserPlugins {
+
+    private static final UUIDProvider DEFAULT_UUID_PROVIDER = UUID::randomUUID;
+    private static volatile UUIDProvider uuidProvider = DEFAULT_UUID_PROVIDER;
+
+    /**
+     * Prevents changing the plugins.
+     */
+    private static volatile boolean lockdown;
+
+    /**
+     * Prevents changing the plugins from then on.
+     * <p>
+     * This allows container-like environments to prevent client messing with plugins.
+     */
+    public static void lockdown() {
+        lockdown = true;
+    }
+
+    /**
+     * Returns true if the plugins were locked down.
+     *
+     * @return true if the plugins were locked down
+     */
+    public static boolean isLockdown() {
+        return lockdown;
+    }
+
+    /**
+     * @param uuidProvider the provider to use for generating {@link UUID}s for elements.
+     */
+    public static void setUUIDProvider(UUIDProvider uuidProvider) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        ThriftyParserPlugins.uuidProvider = uuidProvider;
+    }
+
+    /**
+     * @return a {@link UUID} as dictated by {@link #uuidProvider}. Default is random UUIDs.
+     */
+    public static UUID createUUID() {
+        return uuidProvider.call();
+    }
+
+    public static void reset() {
+        uuidProvider = DEFAULT_UUID_PROVIDER;
+    }
+
+    private ThriftyParserPlugins() {
+        // No instances.
+    }
+
+    /**
+     * A simple provider interface for creating {@link UUID}s.
+     */
+    public interface UUIDProvider {
+
+        /**
+         * @return a {@link UUID}.
+         */
+        UUID call();
+    }
+
+}

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/TypedefElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/TypedefElement.java
@@ -23,6 +23,8 @@ package com.microsoft.thrifty.schema.parser;
 import com.google.auto.value.AutoValue;
 import com.microsoft.thrifty.schema.Location;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -31,6 +33,7 @@ public abstract class TypedefElement {
     public abstract String documentation();
     public abstract TypeElement oldType();
     public abstract String newName();
+    public abstract UUID uuid();
 
     @Nullable
     public abstract AnnotationElement annotations();
@@ -40,7 +43,8 @@ public abstract class TypedefElement {
     public static Builder builder(Location location) {
         return new AutoValue_TypedefElement.Builder()
                 .location(location)
-                .documentation("");
+                .documentation("")
+                .uuid(UUID.randomUUID());
     }
 
     @AutoValue.Builder
@@ -49,6 +53,7 @@ public abstract class TypedefElement {
         Builder documentation(String documentation);
         Builder oldType(TypeElement oldType);
         Builder newName(String newName);
+        Builder uuid(UUID uuid);
         Builder annotations(AnnotationElement annotations);
 
         TypedefElement build();

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/TypedefElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/TypedefElement.java
@@ -44,7 +44,7 @@ public abstract class TypedefElement {
         return new AutoValue_TypedefElement.Builder()
                 .location(location)
                 .documentation("")
-                .uuid(UUID.randomUUID());
+                .uuid(ThriftyParserPlugins.createUUID());
     }
 
     @AutoValue.Builder

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/parser/ThriftParserTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/parser/ThriftParserTest.java
@@ -27,10 +27,14 @@ import com.microsoft.thrifty.schema.Location;
 import com.microsoft.thrifty.schema.NamespaceScope;
 import com.microsoft.thrifty.schema.Requiredness;
 import okio.Okio;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -39,6 +43,19 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.*;
 
 public class ThriftParserTest {
+
+    private static final UUID TEST_UUID = UUID.fromString("ecafa042-668a-4403-a6d3-70983866ffbe");
+
+    @Before
+    public void setup() {
+        ThriftyParserPlugins.setUUIDProvider(() -> TEST_UUID);
+    }
+
+    @After
+    public void tearDown() {
+        ThriftyParserPlugins.reset();
+    }
+
     @Test
     public void namespaces() {
         String thrift =


### PR DESCRIPTION
This is a prototype of trying to tag parsed elements with unique IDs so that one could match them even if you `newBuilder`'d it, you could match back other elements that reference the now-old reference to them. This would allow for one to normalize references in a `Schema` after changing a bunch of elements in it, such as with a preprocessor to edit Schemas before code gen.

If the implementation here looks good, I can proceed with figuring out how to update tests to handle this in a deterministic way