### PR TITLE
Generated nullable annotations for all the fields in union

### DIFF
--- a/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
+++ b/thrifty-java-codegen/src/main/java/com/microsoft/thrifty/gen/ThriftyCodeGenerator.java
@@ -355,6 +355,7 @@ public final class ThriftyCodeGenerator {
                 .addModifiers(Modifier.PRIVATE)
                 .addParameter(builderTypeName, "builder");
 
+        boolean isUnion = type.isUnion();
         for (Field field : type.fields()) {
 
             String name = fieldNamer.getName(field);
@@ -368,7 +369,9 @@ public final class ThriftyCodeGenerator {
                     .addAnnotation(fieldAnnotation(field));
 
             if (emitAndroidAnnotations) {
-                ClassName anno = field.required() ? TypeNames.NOT_NULL : TypeNames.NULLABLE;
+                ClassName anno = isUnion
+                    ? TypeNames.NULLABLE
+                    : (field.required() ? TypeNames.NOT_NULL : TypeNames.NULLABLE);
                 fieldBuilder.addAnnotation(anno);
             }
 


### PR DESCRIPTION
Fixes - https://github.com/Microsoft/thrifty/issues/160. @benjamin-bader do you think we should throw an error if a union is annotated with anything such as required or optional? [Thrift doc](https://thrift.apache.org/docs/idl#union) suggests that union's default value is optional. Does this mean union can be required? It kind of breaks the semantics.