### PR TITLE
Field naming policy updated to use guava's case format

### DIFF
--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/FieldNamingPolicy.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/FieldNamingPolicy.java
@@ -21,12 +21,16 @@
 package com.microsoft.thrifty.schema;
 
 import com.google.common.base.CaseFormat;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
  * Controls the style of names generated for fields.
  */
 public abstract class FieldNamingPolicy {
+    private static final Pattern LOWER_CAMEL_REGEX = Pattern.compile("([a-z]+[A-Z]+\\w+)+");
+    private static final Pattern UPPER_CAMEL_REGEX = Pattern.compile("([A-Z]+[a-z]+\\w+)+");
+
     public abstract String apply(String name);
 
     public FieldNamingPolicy() {
@@ -54,7 +58,7 @@ public abstract class FieldNamingPolicy {
         @Override
         public String apply(String name) {
 
-            CaseFormat caseFormat = CASE_FORMAT(name);
+            CaseFormat caseFormat = caseFormatOf(name);
             if (caseFormat != null) {
                 String formattedName = caseFormat.to(CaseFormat.LOWER_CAMEL, name);
                 // Handle acronym as camel case made it lower case.
@@ -84,32 +88,37 @@ public abstract class FieldNamingPolicy {
      * @return CaseFormat the case format of the string.
      */
     @Nullable
-    private static CaseFormat CASE_FORMAT(String s) {
+    private static CaseFormat caseFormatOf(String s) {
 
         if (s.contains("_")) {
 
-            if (s.toUpperCase().equals(s))
+            if (s.toUpperCase().equals(s)) {
                 return CaseFormat.UPPER_UNDERSCORE;
+            }
 
-            if (s.toLowerCase().equals(s))
+            if (s.toLowerCase().equals(s)) {
                 return CaseFormat.LOWER_UNDERSCORE;
+            }
 
         } else if (s.contains("-")) {
 
-            if (s.toLowerCase().equals(s))
+            if (s.toLowerCase().equals(s)) {
                 return CaseFormat.LOWER_HYPHEN;
+            }
 
         } else {
 
             if (Character.isLowerCase(s.charAt(0))) {
 
-                if (s.matches("([a-z]+[A-Z]+\\w+)+"))
+                if (LOWER_CAMEL_REGEX.matcher(s).matches()) {
                     return null;
+                }
 
             } else {
 
-                if (s.matches("([A-Z]+[a-z]+\\w+)+"))
+                if (UPPER_CAMEL_REGEX.matcher(s).matches()) {
                     return CaseFormat.UPPER_CAMEL;
+                }
             }
         }
 

--- a/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/FieldNamingPolicyTest.java
+++ b/thrifty-schema/src/test/java/com/microsoft/thrifty/schema/FieldNamingPolicyTest.java
@@ -50,4 +50,18 @@ public class FieldNamingPolicyTest {
         assertThat(policy.apply("OAuthToken"), is("OAuthToken"));
         assertThat(policy.apply("SSLFlag"), is("SSLFlag"));
     }
+
+    @Test
+    public void javaPolicyDifferentCaseFormatCamelCaseNames() {
+        FieldNamingPolicy policy = FieldNamingPolicy.JAVA;
+
+        // lower_underscore
+        assertThat(policy.apply("my_field"), is("myField"));
+        // lower-hyphen
+        assertThat(policy.apply("my-field"), is("myField"));
+        // UpperCamel
+        assertThat(policy.apply("MyField"), is("myField"));
+        // UPPER_UNDERSCORE
+        assertThat(policy.apply("MY_FIELD"), is("myField"));
+    }
 }


### PR DESCRIPTION
Fixes - https://github.com/Microsoft/thrifty/issues/163.

There are 2 paths:
1. If the thrift naming matches a CaseFormat, convert it to Lower_camel and handle acronyms.
2. Otherwise, just follow the existing code path.

The CaseFormat detection is taken from https://github.com/google/guava/issues/2212