### PR TITLE
Add UrlTransport + Support for strict mode in BinaryProtocol

### DIFF
--- a/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/conformance/BinaryProtocolConformance.java
+++ b/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/conformance/BinaryProtocolConformance.java
@@ -39,6 +39,6 @@ public class BinaryProtocolConformance extends ConformanceBase {
 
     @Override
     protected Protocol createProtocol(Transport transport) {
-        return new BinaryProtocol(transport);
+        return new BinaryProtocol.Builder(transport).build();
     }
 }

--- a/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/conformance/NonblockingBinaryProtocolConformance.java
+++ b/thrifty-integration-tests/src/test/java/com/microsoft/thrifty/integration/conformance/NonblockingBinaryProtocolConformance.java
@@ -46,6 +46,6 @@ public class NonblockingBinaryProtocolConformance extends ConformanceBase {
 
     @Override
     protected Protocol createProtocol(Transport transport) {
-        return new BinaryProtocol(transport);
+        return new BinaryProtocol.Builder(transport).build();
     }
 }

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/protocol/BinaryProtocol.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/protocol/BinaryProtocol.java
@@ -31,7 +31,7 @@ import java.net.ProtocolException;
 
 /**
  * An implementation of the simple Thrift binary protocol.
- *
+ * <p>
  * <p>Instances of this class are <em>not</em> threadsafe.
  */
 public class BinaryProtocol extends Protocol {
@@ -60,18 +60,49 @@ public class BinaryProtocol extends Protocol {
     private boolean strictRead;
     private boolean strictWrite;
 
-    public BinaryProtocol(Transport transport) {
-        this(transport, -1, -1);
+    public static class Builder {
+
+        private Transport transport;
+        private int stringLengthLimit = -1;
+        private int containerLengthLimit = -1;
+        private boolean strictRead;
+        private boolean strictWrite;
+
+        public Builder(Transport transport) {
+            this.transport = transport;
+        }
+
+        public Builder setStringLengthLimit(int stringLengthLimit) {
+            this.stringLengthLimit = stringLengthLimit;
+            return this;
+        }
+
+        public Builder setContainerLengthLimit(int containerLengthLimit) {
+            this.containerLengthLimit = containerLengthLimit;
+            return this;
+        }
+
+        public Builder setStrictRead(boolean strictRead) {
+            this.strictRead = strictRead;
+            return this;
+        }
+
+        public Builder setStrictWrite(boolean strictWrite) {
+            this.strictWrite = strictWrite;
+            return this;
+        }
+
+        public BinaryProtocol build() {
+            return new BinaryProtocol(this);
+        }
     }
 
-    public BinaryProtocol(Transport transport, int stringLengthLimit) {
-        this(transport, stringLengthLimit, -1);
-    }
-
-    public BinaryProtocol(Transport transport, int stringLengthLimit, int containerLengthLimit) {
-        super(transport);
-        this.stringLengthLimit = stringLengthLimit;
-        this.containerLengthLimit = containerLengthLimit;
+    BinaryProtocol(Builder builder) {
+        super(builder.transport);
+        this.stringLengthLimit = builder.stringLengthLimit;
+        this.containerLengthLimit = builder.containerLengthLimit;
+        this.strictRead = builder.strictRead;
+        this.strictWrite = builder.strictWrite;
     }
 
     @Override
@@ -170,8 +201,8 @@ public class BinaryProtocol extends Protocol {
     public void writeI32(int i32) throws IOException {
         buffer[0] = (byte) ((i32 >> 24) & 0xFF);
         buffer[1] = (byte) ((i32 >> 16) & 0xFF);
-        buffer[2] = (byte) ((i32 >>  8) & 0xFF);
-        buffer[3] = (byte)  (i32        & 0xFF);
+        buffer[2] = (byte) ((i32 >> 8) & 0xFF);
+        buffer[3] = (byte) (i32 & 0xFF);
 
         transport.write(buffer, 0, 4);
     }
@@ -184,8 +215,8 @@ public class BinaryProtocol extends Protocol {
         buffer[3] = (byte) ((i64 >> 32) & 0xFF);
         buffer[4] = (byte) ((i64 >> 24) & 0xFF);
         buffer[5] = (byte) ((i64 >> 16) & 0xFF);
-        buffer[6] = (byte) ((i64 >>  8) & 0xFF);
-        buffer[7] = (byte)  (i64        & 0xFF);
+        buffer[6] = (byte) ((i64 >> 8) & 0xFF);
+        buffer[7] = (byte) (i64 & 0xFF);
 
         transport.write(buffer, 0, 8);
     }
@@ -314,7 +345,7 @@ public class BinaryProtocol extends Protocol {
     public short readI16() throws IOException {
         readFully(buffer, 2);
         return (short) (((buffer[0] & 0xFF) << 8)
-                       | (buffer[1] & 0xFF));
+                | (buffer[1] & 0xFF));
     }
 
     @Override
@@ -322,9 +353,9 @@ public class BinaryProtocol extends Protocol {
         readFully(buffer, 4);
 
         return ((buffer[0] & 0xFF) << 24)
-             | ((buffer[1] & 0xFF) << 16)
-             | ((buffer[2] & 0xFF) <<  8)
-             |  (buffer[3] & 0xFF);
+                | ((buffer[1] & 0xFF) << 16)
+                | ((buffer[2] & 0xFF) << 8)
+                | (buffer[3] & 0xFF);
     }
 
     @Override
@@ -332,13 +363,13 @@ public class BinaryProtocol extends Protocol {
         readFully(buffer, 8);
 
         return ((buffer[0] & 0xFFL) << 56)
-             | ((buffer[1] & 0xFFL) << 48)
-             | ((buffer[2] & 0xFFL) << 40)
-             | ((buffer[3] & 0xFFL) << 32)
-             | ((buffer[4] & 0xFFL) << 24)
-             | ((buffer[5] & 0xFFL) << 16)
-             | ((buffer[6] & 0xFFL) <<  8)
-             |  (buffer[7] & 0xFFL);
+                | ((buffer[1] & 0xFFL) << 48)
+                | ((buffer[2] & 0xFFL) << 40)
+                | ((buffer[3] & 0xFFL) << 32)
+                | ((buffer[4] & 0xFFL) << 24)
+                | ((buffer[5] & 0xFFL) << 16)
+                | ((buffer[6] & 0xFFL) << 8)
+                | (buffer[7] & 0xFFL);
     }
 
     @Override

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/transport/URLTransport.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/transport/URLTransport.java
@@ -1,0 +1,122 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
+package com.microsoft.thrifty.transport;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class URLTransport extends Transport {
+
+    private URL url;
+    private int timeout = 0;
+
+    private HttpURLConnection connection;
+    private InputStream inputStream;
+    private ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    public static class Builder {
+
+        private URL url;
+        private int timeout = 0;
+
+        public Builder(URL url) {
+            this.url = url;
+        }
+
+        public Builder setTimeout(int timeout) {
+            if (timeout < 0) {
+                throw new IllegalArgumentException("timeout can not be negative");
+            }
+            this.timeout = timeout;
+            return this;
+        }
+
+        public URLTransport build() {
+            return new URLTransport(this);
+        }
+    }
+
+    URLTransport(Builder builder) {
+        this.url = builder.url;
+        this.timeout = builder.timeout;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int count) throws IOException {
+        return inputStream.read(buffer, offset, count);
+    }
+
+    @Override
+    public void write(byte[] buffer, int offset, int count) throws IOException {
+        outputStream.write(buffer, offset, count);
+    }
+
+    @Override
+    public void flush() throws IOException {
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        byte[] data = outputStream.toByteArray();
+        outputStream.reset();
+
+        connection.setRequestMethod("POST");
+        connection.setConnectTimeout(timeout);
+        connection.setDoOutput(true);
+
+        connection.setRequestProperty("Accept", "application/x-thrift");
+        connection.setRequestProperty("Content-Type", "application/x-thrift");
+
+        connection.connect();
+
+        connection.getOutputStream().write(data);
+        int code = connection.getResponseCode();
+        if (code != HttpURLConnection.HTTP_OK) {
+            throw new IOException("HTTP response code not OK");
+        }
+
+        this.inputStream = connection.getInputStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+        HttpURLConnection connection = this.connection;
+        InputStream inputStream = this.inputStream;
+        OutputStream outputStream = this.outputStream;
+
+        this.connection = null;
+
+        try {
+            inputStream.close();
+        } catch (Exception ignored) {
+        }
+
+        try {
+            outputStream.close();
+        } catch (Exception ignored) {
+        }
+
+        connection.disconnect();
+    }
+}

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/BinaryProtocolTest.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/BinaryProtocolTest.java
@@ -43,7 +43,7 @@ public class BinaryProtocolTest {
         buffer.writeInt(3);
         buffer.writeUtf8("foo");
 
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
         assertThat(proto.readString(), is("foo"));
     }
 
@@ -53,7 +53,7 @@ public class BinaryProtocolTest {
         buffer.writeInt(13);
         buffer.writeUtf8("foobarbazquux");
 
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer), 12);
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).setStringLengthLimit(12).build();
 
         try {
             proto.readString();
@@ -69,7 +69,7 @@ public class BinaryProtocolTest {
         buffer.writeInt(4);
         buffer.writeUtf8("abcd");
 
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
         assertThat(proto.readBinary(), equalTo(ByteString.encodeUtf8("abcd")));
     }
 
@@ -79,7 +79,7 @@ public class BinaryProtocolTest {
         buffer.writeInt(6);
         buffer.writeUtf8("kaboom");
 
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer), 4);
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).setStringLengthLimit(4).build();
         try {
             proto.readBinary();
             fail();
@@ -91,7 +91,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeByte() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         proto.writeByte((byte) 127);
         assertThat(buffer.readByte(), equalTo((byte) 127));
@@ -100,7 +100,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeI16() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         proto.writeI16(Short.MAX_VALUE);
         assertThat(buffer.readShort(), equalTo(Short.MAX_VALUE));
@@ -114,7 +114,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeI32() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         proto.writeI32(0xFF0F00FF);
         assertThat(buffer.readInt(), equalTo(0xFF0F00FF));
@@ -123,7 +123,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeI64() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         proto.writeI64(0x12345678);
         assertThat(buffer.readLong(), equalTo(0x12345678L));
@@ -132,7 +132,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeDouble() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         // Doubles go on the wire as the 8-byte blobs from
         // Double#doubleToLongBits().
@@ -143,7 +143,7 @@ public class BinaryProtocolTest {
     @Test
     public void writeString() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol proto = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol proto = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
 
         proto.writeString("here is a string");
         assertThat(buffer.readInt(), equalTo(16));
@@ -179,7 +179,7 @@ public class BinaryProtocolTest {
         ByteString binaryData = ByteString.decodeHex(payload);
         Buffer buffer = new Buffer();
         buffer.write(binaryData);
-        BinaryProtocol protocol = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol protocol = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
         read(protocol);
     }
 

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/DecorationgProtocolTest.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/DecorationgProtocolTest.java
@@ -31,7 +31,7 @@ public final class DecorationgProtocolTest {
 
     @Test
     public void testCtor() {
-        Protocol binaryProtocol = new BinaryProtocol(new BufferTransport());
+        Protocol binaryProtocol = new BinaryProtocol.Builder(new BufferTransport()).build();
         Protocol decoratingProtocol = new DecoratingProtocol(binaryProtocol) {};
         assertThat(decoratingProtocol.transport).isSameAs(binaryProtocol.transport);
     }

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/util/ProtocolUtilTest.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/util/ProtocolUtilTest.java
@@ -54,7 +54,7 @@ public class ProtocolUtilTest {
     @Before
     public void setup() {
         buffer = new Buffer();
-        protocol = new BinaryProtocol(new BufferTransport(buffer));
+        protocol = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
         mockProtocol = mock(Protocol.class);
     }
 
@@ -166,7 +166,7 @@ public class ProtocolUtilTest {
     @Test
     public void throwsProtocolExceptionOnUnknownTTypeValue() throws Exception {
         Buffer buffer = new Buffer();
-        BinaryProtocol protocol = new BinaryProtocol(new BufferTransport(buffer));
+        BinaryProtocol protocol = new BinaryProtocol.Builder(new BufferTransport(buffer)).build();
         protocol.writeStructBegin("Test");
         protocol.writeFieldBegin("num", 1, TType.I32);
         protocol.writeI32(2);


### PR DESCRIPTION
Mostly based on the official Thrift implementation.