### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,15 +30,15 @@ allprojects {
     project.ext {
         libraries = [
                 guava: [
-                        'com.google.guava:guava:21.0'
+                        'com.google.guava:guava:23.0'
                 ],
 
                 okio: [
-                        'com.squareup.okio:okio:1.11.0'
+                        'com.squareup.okio:okio:1.14.1'
                 ],
 
                 javaPoet: [
-                        'com.squareup:javapoet:1.8.0'
+                        'com.squareup:javapoet:1.11.1'
                 ],
 
                 testing: [
@@ -61,7 +61,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
     }
 }
 

--- a/thrifty-schema/build.gradle
+++ b/thrifty-schema/build.gradle
@@ -19,7 +19,7 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 plugins {
-    id 'net.ltgt.apt' version '0.9'
+    id 'net.ltgt.apt' version '0.15'
     id 'antlr'
 }
 
@@ -30,20 +30,20 @@ generateGrammarSource {
 }
 
 tasks.withType(JavaCompile) {
-    options.annotationProcessorPath = configurations.apt
+    options.annotationProcessorPath = configurations.annotationProcessor
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.6"
-    implementation "org.antlr:antlr4:4.6"
+    antlr "org.antlr:antlr4:4.7.1"
+    implementation "org.antlr:antlr4:4.7.1"
 
     implementation libraries.okio
 
     api 'com.google.code.findbugs:jsr305:3.0.1'
     api libraries.guava
 
-    compileOnly 'com.google.auto.value:auto-value:1.3'
-    apt 'com.google.auto.value:auto-value:1.3'
+    api 'com.google.auto.value:auto-value-annotations:1.6'
+    annotationProcessor 'com.google.auto.value:auto-value:1.6'
 
     testImplementation libraries.testing
 }

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FieldElement.java
@@ -38,12 +38,6 @@ public abstract class FieldElement {
                 .uuid(ThriftyParserPlugins.createUUID());
     }
 
-    public FieldElement withId(int fieldId) {
-        return new AutoValue_FieldElement.Builder(this)
-                .fieldId(fieldId)
-                .build();
-    }
-
     public abstract Location location();
     public abstract String documentation();
     public abstract int fieldId();

--- a/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
+++ b/thrifty-schema/src/main/java/com/microsoft/thrifty/schema/parser/FunctionElement.java
@@ -41,10 +41,6 @@ public abstract class FunctionElement {
                 .uuid(ThriftyParserPlugins.createUUID());
     }
 
-    public static Builder builder(FunctionElement element) {
-        return new AutoValue_FunctionElement.Builder(element);
-    }
-
     public abstract Location location();
     public abstract String documentation();
     public abstract boolean oneWay();


### PR DESCRIPTION
AutoValue and tbroyer's apt plugin necessitate slightly more involved changes.  AutoValue in particular is now two separate artifacts (yay!), so we don't have to include repackaged guava in the runtime classpath anymore.  Its builders have changed a bit, but as it turns out our code that used the changed bits was dead code.  Baleeted.

I've changed the autovalue-annotations from `compileOnly` to `api` because it turns out that the annotations have class retention, so these annotations are therefore actually part of our API. 