### PR TITLE
Use NameAllocators to avoid name conflicts

### DIFF
--- a/thrifty-integration-tests/ClientThriftTest.thrift
+++ b/thrifty-integration-tests/ClientThriftTest.thrift
@@ -28,6 +28,7 @@
  */
 
 namespace java com.microsoft.thrifty.integration.gen
+namespace kt com.microsoft.thrifty.integration.kgen
 
 /**
  * Docstring!

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -19,6 +19,7 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 
+apply plugin: 'kotlin'
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 
@@ -28,6 +29,8 @@ dependencies {
     testImplementation project(':thrifty-runtime')
     testImplementation project(':thrifty-test-server')
     testImplementation libraries.guava
+
+    testImplementation libraries.kotlin
 
     testImplementation 'junit:junit:4.11'
 }
@@ -57,8 +60,23 @@ task compileTestThrift(type: Exec) {
     args = ['-jar', jarTask.archivePath.absolutePath, "--out=$projectDir/build/generated-src/thrifty", "$projectDir/ClientThriftTest.thrift"]
 }
 
+task kompileTestThrift(type: Exec) {
+    def jarTask = project.tasks['shadowJar'] as Jar
+
+    dependsOn jarTask
+
+    executable 'java'
+    args = ['-jar', jarTask.archivePath.absolutePath, "--out=$projectDir/build/generated-src/thrifty", "--kotlin", "$projectDir/ClientThriftTest.thrift"]
+}
+
+compileTestKotlin {
+    dependsOn compileTestThrift
+    dependsOn kompileTestThrift
+}
+
 compileTestJava {
     dependsOn compileTestThrift
+    dependsOn kompileTestThrift
     options.compilerArgs += [ '-Xep:ReferenceEquality:OFF' ]
 }
 

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -137,6 +137,19 @@ class KotlinCodeGeneratorTest {
         struct.funSpecs.any { it.name == "equals"   } shouldBe false
     }
 
+    @Test fun `exceptions with reserved field names get renamed fields`() {
+        val thrift = """
+            namespace kt com.test
+
+            exception Fail { 1: required list<i32> Message }
+        """.trimIndent()
+
+        val schema = load(thrift)
+        val specs = KotlinCodeGenerator(FieldNamingPolicy.JAVA).generate(schema)
+        val xception = specs.single().members.single() as TypeSpec
+        xception.propertySpecs.single().name shouldBe "message_"
+    }
+
     private fun generate(thrift: String): List<FileSpec> {
         return KotlinCodeGenerator().generate(load(thrift))
     }


### PR DESCRIPTION
Integrates Kotlin codegen into `thrifty-integration-tests`, whose test thrift file uncovered the bug in the first place.  All test runs will now verify that its generated Kotlin at least compiles.

Fixes #193