### PR TITLE
Consolidate namespaces into UserElement and mixin

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/AbstractUserElementBuilder.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/AbstractUserElementBuilder.kt
@@ -54,6 +54,11 @@ abstract class AbstractUserElementBuilder<
         return this as TBuilder
     }
 
+    fun namespaces(namespaces: Map<NamespaceScope, String>): TBuilder {
+        mixin = mixin.toBuilder().namespaces(namespaces).build()
+        return this as TBuilder
+    }
+
     fun type(type: TElement): TBuilder {
         mixin = mixin.toBuilder()
                 .name(type.name)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/BuiltinType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/BuiltinType.kt
@@ -50,7 +50,7 @@ class BuiltinType internal constructor(
     }
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
-        return BuiltinType(name, ThriftType.merge(this.annotations, annotations))
+        return BuiltinType(name, mergeAnnotations(this.annotations, annotations))
     }
 
     override fun equals(other: Any?): Boolean {

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumMember.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumMember.kt
@@ -31,8 +31,8 @@ class EnumMember private constructor(
         val value: Int
 ) : UserElement by mixin {
 
-    internal constructor(element: EnumMemberElement)
-            : this(UserElementMixin(element), element.value)
+    internal constructor(element: EnumMemberElement, namespaces: Map<NamespaceScope, String>)
+            : this(UserElementMixin(element, namespaces), element.value)
 
     private constructor(builder: Builder)
             : this(builder.mixin, builder.value)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumType.kt
@@ -29,15 +29,11 @@ class EnumType : UserType {
 
     val members: List<EnumMember>
 
-    internal constructor(program: Program, element: EnumElement) : super(program.namespaces, UserElementMixin(element)) {
-        this.members = element.members.map { EnumMember(it) }
+    internal constructor(element: EnumElement, namespaces: Map<NamespaceScope, String>): super(UserElementMixin(element, namespaces)) {
+        this.members = element.members.map { EnumMember(it, namespaces) }
     }
 
-    internal constructor(element: EnumElement, namespaces: Map<NamespaceScope, String>): super(namespaces, UserElementMixin(element)) {
-        this.members = element.members.map { EnumMember(it) }
-    }
-
-    private constructor(builder: Builder) : super(builder.namespaces, builder.mixin) {
+    private constructor(builder: Builder) : super(builder.mixin) {
         this.members = builder.members
     }
 
@@ -55,7 +51,7 @@ class EnumType : UserType {
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
         return toBuilder()
-                .annotations(ThriftType.merge(this.annotations, annotations))
+                .annotations(mergeAnnotations(this.annotations, annotations))
                 .build()
     }
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Field.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Field.kt
@@ -23,9 +23,9 @@ package com.microsoft.thrifty.schema
 import com.microsoft.thrifty.schema.parser.ConstValueElement
 import com.microsoft.thrifty.schema.parser.FieldElement
 
-class Field internal constructor(
+class Field private constructor(
         private val element: FieldElement,
-        private val mixin: UserElementMixin = UserElementMixin(element),
+        private val mixin: UserElementMixin,
         private var type_: ThriftType? = null
 ) : UserElement by mixin {
 
@@ -59,6 +59,9 @@ class Field internal constructor(
                 if (it.isTypedef) it.name else null
             }
         }
+
+    internal constructor(element: FieldElement, namespaces: Map<NamespaceScope, String>)
+            : this(element, UserElementMixin(element, namespaces))
 
     fun toBuilder(): Builder = Builder(this)
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ListType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ListType.kt
@@ -33,7 +33,7 @@ class ListType internal constructor(
     override fun <T> accept(visitor: ThriftType.Visitor<T>): T = visitor.visitList(this)
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
-        return ListType(elementType, ThriftType.merge(this.annotations, annotations))
+        return ListType(elementType, mergeAnnotations(this.annotations, annotations))
     }
 
     fun toBuilder(): Builder {

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/MapType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/MapType.kt
@@ -34,7 +34,7 @@ class MapType internal constructor(
     override fun <T> accept(visitor: ThriftType.Visitor<T>): T = visitor.visitMap(this)
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
-        return MapType(keyType, valueType, ThriftType.merge(this.annotations, annotations))
+        return MapType(keyType, valueType, mergeAnnotations(this.annotations, annotations))
     }
 
     fun toBuilder(): Builder = Builder(this)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Program.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Program.kt
@@ -43,17 +43,17 @@ class Program internal constructor(element: ThriftFileElement) {
 
     val constants: List<Constant> = element.constants.map { Constant(it, namespaces) }
 
-    val enums: List<EnumType> = element.enums.map { EnumType(this, it) }
+    val enums: List<EnumType> = element.enums.map { EnumType(it, namespaces) }
 
-    val structs: List<StructType>    = element.structs.map { StructType(this, it) }
+    val structs: List<StructType>    = element.structs.map { StructType(it, namespaces) }
 
-    val unions: List<StructType>     = element.unions.map { StructType(this, it) }
+    val unions: List<StructType>     = element.unions.map { StructType(it, namespaces) }
 
-    val exceptions: List<StructType> = element.exceptions.map { StructType(this, it) }
+    val exceptions: List<StructType> = element.exceptions.map { StructType(it, namespaces) }
 
-    val typedefs: List<TypedefType>  = element.typedefs.map { TypedefType(this, it) }
+    val typedefs: List<TypedefType>  = element.typedefs.map { TypedefType(it, namespaces) }
 
-    val services: List<ServiceType>  = element.services.map { ServiceType(this, it) }
+    val services: List<ServiceType>  = element.services.map { ServiceType(it, namespaces) }
 
     val location: Location = element.location
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ServiceMethod.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ServiceMethod.kt
@@ -24,22 +24,22 @@ import com.microsoft.thrifty.schema.parser.FunctionElement
 
 import java.util.LinkedHashMap
 
-class ServiceMethod internal constructor(
+class ServiceMethod private constructor(
         private val element: FunctionElement,
-        private val mixin: UserElementMixin = UserElementMixin(element),
-        val parameters: List<Field> = element.params.map { Field(it) },
-        val exceptions: List<Field> = element.exceptions.map { Field(it) },
+        private val mixin: UserElementMixin,
+        val parameters: List<Field> = element.params.map { Field(it, mixin.namespaces) },
+        val exceptions: List<Field> = element.exceptions.map { Field(it, mixin.namespaces) },
         private var returnType_: ThriftType? = null
 ) : UserElement by mixin {
 
     val returnType: ThriftType
         get() = returnType_!!
 
-    override val isDeprecated: Boolean
-        get() = mixin.isDeprecated
-
     val oneWay: Boolean
         get() = element.oneWay
+
+    internal constructor(element: FunctionElement, namespaces: Map<NamespaceScope, String>)
+            : this(element, UserElementMixin(element, namespaces))
 
     fun toBuilder(): Builder {
         return Builder(this)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ServiceType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ServiceType.kt
@@ -36,13 +36,12 @@ class ServiceType : UserType {
     var extendsService: ThriftType? = null
         private set
 
-    internal constructor(program: Program, element: ServiceElement) : super(program.namespaces, UserElementMixin(element)) {
-
+    internal constructor(element: ServiceElement, namespaces: Map<NamespaceScope, String>) : super(UserElementMixin(element, namespaces)) {
         this.extendsServiceType = element.extendsService
-        this.methods = element.functions.map { ServiceMethod(it) }
+        this.methods = element.functions.map { ServiceMethod(it, namespaces) }
     }
 
-    private constructor(builder: Builder) : super(builder.namespaces, builder.mixin) {
+    private constructor(builder: Builder) : super(builder.mixin) {
         this.methods = builder.methods
         this.extendsServiceType = builder.extendsServiceType
         this.extendsService = builder.extendsService
@@ -54,7 +53,7 @@ class ServiceType : UserType {
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
         return toBuilder()
-                .annotations(ThriftType.merge(this.annotations, annotations))
+                .annotations(mergeAnnotations(this.annotations, annotations))
                 .build()
     }
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/SetType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/SetType.kt
@@ -33,7 +33,7 @@ class SetType internal constructor(
     override fun <T> accept(visitor: ThriftType.Visitor<T>): T = visitor.visitSet(this)
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
-        return SetType(elementType, ThriftType.merge(this.annotations, annotations))
+        return SetType(elementType, mergeAnnotations(this.annotations, annotations))
     }
 
     fun toBuilder(): Builder = Builder(this)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/StructType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/StructType.kt
@@ -40,14 +40,13 @@ class StructType : UserType {
     val isException: Boolean
         get() = structType === StructElement.Type.EXCEPTION
 
-    internal constructor(program: Program, element: StructElement) : super(program.namespaces, UserElementMixin(element)) {
-
+    internal constructor(element: StructElement, namespaces: Map<NamespaceScope, String>)
+            : super(UserElementMixin(element, namespaces)) {
         this.structType = element.type
-        this.fields = element.fields
-                .map { Field(it) }
+        this.fields = element.fields.map { Field(it, namespaces) }
     }
 
-    private constructor(builder: Builder) : super(builder.namespaces, builder.mixin) {
+    private constructor(builder: Builder) : super(builder.mixin) {
         this.structType = builder.structType
         this.fields = builder.fields
     }
@@ -60,7 +59,7 @@ class StructType : UserType {
 
     override fun withAnnotations(annotations: Map<String, String>): ThriftType {
         return toBuilder()
-                .annotations(ThriftType.merge(this.annotations, annotations))
+                .annotations(mergeAnnotations(this.annotations, annotations))
                 .build()
     }
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ThriftType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/ThriftType.kt
@@ -303,7 +303,6 @@ abstract class ThriftType internal constructor(
     }
 
     companion object {
-        @JvmStatic
         protected fun merge(
                 baseAnnotations: Map<String, String>,
                 newAnnotations: Map<String, String>): Map<String, String> {
@@ -312,5 +311,14 @@ abstract class ThriftType internal constructor(
             merged.putAll(newAnnotations)
             return merged
         }
+    }
+}
+
+internal fun mergeAnnotations(
+        baseAnnotations: Map<String, String>,
+        newAnnotations: Map<String, String>): Map<String, String> {
+    return mutableMapOf<String, String>().apply {
+        putAll(baseAnnotations)
+        putAll(newAnnotations)
     }
 }

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElement.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElement.kt
@@ -80,6 +80,28 @@ interface UserElement {
      * @return all annotations present on this element.
      */
     val annotations: Map<String, String>
+
+    /**
+     * A map of namespaces to which this element belongs.
+     */
+    val namespaces: Map<NamespaceScope, String>
+
+    /**
+     * Gets the first namespace found for the given list of scopes.
+     *
+     * Iterates over the scopes in the order provided, returning the first
+     * non-null namespace found for this element.
+     *
+     * @param scopes The list of scopes to search.
+     * @return the first namespace found corresponding to one of the given
+     *         [scopes], or null.
+     */
+    fun getNamespaceFor(vararg scopes: NamespaceScope): String? {
+        for (s in scopes) {
+            namespaces[s]?.let { return it }
+        }
+        return null
+    }
 }
 
 /**

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElementMixin.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElementMixin.kt
@@ -21,6 +21,7 @@
 package com.microsoft.thrifty.schema
 
 import com.microsoft.thrifty.schema.parser.AnnotationElement
+import com.microsoft.thrifty.schema.parser.ConstElement
 import com.microsoft.thrifty.schema.parser.EnumElement
 import com.microsoft.thrifty.schema.parser.EnumMemberElement
 import com.microsoft.thrifty.schema.parser.FieldElement
@@ -41,31 +42,50 @@ internal data class UserElementMixin(
         override val name: String,
         override val location: Location,
         override val documentation: String,
-        override val annotations: Map<String, String>
+        override val annotations: Map<String, String>,
+        override val namespaces: Map<NamespaceScope, String>
 ) : UserElement {
     override val isDeprecated: Boolean
         get() = hasThriftOrJavadocAnnotation("deprecated")
 
-    constructor(struct: StructElement) : this(struct.uuid, struct.name, struct.location, struct.documentation, struct.annotations)
-    constructor(field: FieldElement) : this(field.uuid, field.name, field.location, field.documentation, field.annotations)
-    constructor(enumElement: EnumElement) : this(enumElement.uuid, enumElement.name, enumElement.location, enumElement.documentation, enumElement.annotations)
-    constructor(member: EnumMemberElement) : this(member.uuid, member.name, member.location, member.documentation, member.annotations)
-    constructor(element: TypedefElement) : this(element.uuid, element.newName, element.location, element.documentation, element.annotations)
-    constructor(element: ServiceElement) : this(element.uuid, element.name, element.location, element.documentation, element.annotations)
-    constructor(element: FunctionElement) : this(element.uuid, element.name, element.location, element.documentation, element.annotations)
+    constructor(struct: StructElement, namespaces: Map<NamespaceScope, String>)
+            : this(struct.uuid, struct.name, struct.location, struct.documentation, struct.annotations, namespaces)
+
+    constructor(field: FieldElement, namespaces: Map<NamespaceScope, String>)
+            : this(field.uuid, field.name, field.location, field.documentation, field.annotations, namespaces)
+
+    constructor(enumElement: EnumElement, namespaces: Map<NamespaceScope, String>)
+            : this(enumElement.uuid, enumElement.name, enumElement.location, enumElement.documentation, enumElement.annotations, namespaces)
+
+    constructor(member: EnumMemberElement, namespaces: Map<NamespaceScope, String>)
+            : this(member.uuid, member.name, member.location, member.documentation, member.annotations, namespaces)
+
+    constructor(element: TypedefElement, namespaces: Map<NamespaceScope, String>)
+            : this(element.uuid, element.newName, element.location, element.documentation, element.annotations, namespaces)
+
+    constructor(element: ServiceElement, namespaces: Map<NamespaceScope, String>)
+            : this(element.uuid, element.name, element.location, element.documentation, element.annotations, namespaces)
+
+    constructor(element: FunctionElement, namespaces: Map<NamespaceScope, String>)
+            : this(element.uuid, element.name, element.location, element.documentation, element.annotations, namespaces)
+
+    constructor(element: ConstElement, namespaces: Map<NamespaceScope, String>)
+            : this(element.uuid, element.name, element.location, element.documentation, emptyMap(), namespaces)
 
     constructor(
             uuid: UUID,
             name: String,
             location: Location,
             documentation: String,
-            annotationElement: AnnotationElement?) : this(
+            annotationElement: AnnotationElement?,
+            namespaces: Map<NamespaceScope, String>) : this(
 
             uuid,
             name,
             location,
             documentation,
-            annotationElement?.values?.toMap() ?: emptyMap()
+            annotationElement?.values?.toMap() ?: emptyMap(),
+            namespaces
     )
 
     private constructor(builder: Builder) : this(
@@ -73,7 +93,8 @@ internal data class UserElementMixin(
             name = builder.name,
             location = builder.location,
             documentation = builder.documentation,
-            annotations = builder.annotations
+            annotations = builder.annotations,
+            namespaces = builder.namespaces
     )
 
     /**
@@ -102,6 +123,7 @@ internal data class UserElementMixin(
                 + ", location=" + location
                 + ", documentation='" + documentation + "'"
                 + ", annotations=" + annotations
+                + ", namespaces=" + namespaces
                 + '}'.toString())
     }
 
@@ -115,6 +137,7 @@ internal data class UserElementMixin(
         var location: Location = userElement.location
         var documentation: String = userElement.documentation
         var annotations: Map<String, String> = userElement.annotations
+        var namespaces: Map<NamespaceScope, String> = userElement.namespaces
 
         fun uuid(uuid: UUID): Builder = apply {
             this.uuid = uuid
@@ -138,6 +161,10 @@ internal data class UserElementMixin(
 
         fun annotations(annotations: Map<String, String>): Builder = apply {
             this.annotations = annotations
+        }
+
+        fun namespaces(namespaces: Map<NamespaceScope, String>): Builder = apply {
+            this.namespaces = namespaces
         }
 
         fun build(): UserElementMixin = UserElementMixin(this)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserType.kt
@@ -27,28 +27,11 @@ import java.util.Objects
  * exceptions, services, and typedefs.
  */
 abstract class UserType internal constructor(
-        private val namespaces: Map<NamespaceScope, String>,
         private val mixin: UserElementMixin
 ) : ThriftType(mixin.name), UserElement by mixin {
 
     override val isDeprecated: Boolean
         get() = mixin.isDeprecated
-
-    internal constructor(program: Program, mixin: UserElementMixin) : this(program.namespaces, mixin)
-
-    fun getNamespaceFor(namespace: NamespaceScope): String? {
-        return when (namespace) {
-            NamespaceScope.ALL -> namespaces[namespace]
-            else -> namespaces[namespace] ?: namespaces[NamespaceScope.ALL]
-        }
-    }
-
-    fun getNamespaceFor(vararg scopes: NamespaceScope): String? {
-        for (s in scopes) {
-            namespaces[s]?.let { return it }
-        }
-        return null
-    }
 
     override val name: String = mixin.name
 
@@ -56,24 +39,17 @@ abstract class UserType internal constructor(
         if (!super.equals(other)) return false
         if (other !is UserType) return false
 
-        return this.mixin == other.mixin && this.namespaces == other.namespaces
+        return this.mixin == other.mixin
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(super.hashCode(), mixin, namespaces)
+        return Objects.hash(super.hashCode(), mixin)
     }
 
-    abstract class UserTypeBuilder<TType : UserType, TBuilder : UserType.UserTypeBuilder<TType, TBuilder>> internal constructor(
+    abstract class UserTypeBuilder<
+            TType : UserType,
+            TBuilder : UserType.UserTypeBuilder<TType, TBuilder>
+    > internal constructor(
             type: TType
-    ) : AbstractUserElementBuilder<TType, TBuilder>(type.mixin) {
-
-        internal var namespaces: Map<NamespaceScope, String> = type.namespaces
-
-        fun namespaces(namespaces: Map<NamespaceScope, String>): TBuilder {
-            this.namespaces = namespaces
-
-            @Suppress("UNCHECKED_CAST")
-            return this as TBuilder
-        }
-    }
+    ) : AbstractUserElementBuilder<TType, TBuilder>(type.mixin)
 }

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/ConstantTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/ConstantTest.kt
@@ -294,17 +294,7 @@ class ConstantTest {
                 name,
                 value)
 
-        return Constant(element, emptyMap()).also {
-            try {
-                val field = Constant::class.java.getDeclaredField("type_")
-                field.isAccessible = true
-                field.set(it, thriftType)
-            } catch (e: NoSuchFieldException) {
-                throw AssertionError(e)
-            } catch (e: IllegalAccessException) {
-                throw AssertionError(e)
-            }
-        }
+        return Constant(element, emptyMap(), thriftType)
     }
 
     private fun makeTypedef(oldType: ThriftType, newName: String): TypedefType {
@@ -313,16 +303,6 @@ class ConstantTest {
                 TypeElement.scalar(loc, "does_not_matter", null),
                 newName)
 
-        return TypedefType(emptyMap(), element).also {
-            try {
-                val field = TypedefType::class.java.getDeclaredField("oldType_")
-                field.isAccessible = true
-                field.set(it, oldType)
-            } catch (e: IllegalAccessException) {
-                throw AssertionError(e)
-            } catch (e: NoSuchFieldException) {
-                throw AssertionError(e)
-            }
-        }
+        return TypedefType(element, emptyMap(), oldType)
     }
 }

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/FieldTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/FieldTest.kt
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap
 import com.microsoft.thrifty.schema.parser.AnnotationElement
 import com.microsoft.thrifty.schema.parser.FieldElement
 import com.microsoft.thrifty.schema.parser.TypeElement
-import org.junit.Ignore
 import org.junit.Test
 
 import java.util.Collections
@@ -48,7 +47,7 @@ class FieldTest {
         requiredness = Requiredness.REQUIRED
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.required)
         assertFalse(field.optional)
     }
@@ -57,7 +56,7 @@ class FieldTest {
     fun optionalFields() {
         requiredness = Requiredness.OPTIONAL
         val element = field()
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertFalse(field.required)
         assertTrue(field.optional)
     }
@@ -65,7 +64,7 @@ class FieldTest {
     @Test
     fun defaultFields() {
         val element = field()
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertFalse(field.required)
         assertFalse(field.optional)
     }
@@ -73,7 +72,7 @@ class FieldTest {
     @Test
     fun unredactedAndUnobfuscatedByDefault() {
         val element = field()
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertFalse(field.isRedacted)
         assertFalse(field.isObfuscated)
     }
@@ -83,7 +82,7 @@ class FieldTest {
         annotations = annotation("thrifty.redacted")
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isRedacted)
     }
 
@@ -92,7 +91,7 @@ class FieldTest {
         annotations = annotation("redacted")
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isRedacted)
     }
 
@@ -101,7 +100,7 @@ class FieldTest {
         documentation = "/** @redacted */"
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isRedacted)
     }
 
@@ -110,7 +109,7 @@ class FieldTest {
         annotations = annotation("thrifty.obfuscated")
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isObfuscated)
     }
 
@@ -119,7 +118,7 @@ class FieldTest {
         annotations = annotation("obfuscated")
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isObfuscated)
     }
 
@@ -128,14 +127,14 @@ class FieldTest {
         documentation = "/** @obfuscated */"
         val element = field()
 
-        val field = Field(element)
+        val field = Field(element, emptyMap())
         assertTrue(field.isObfuscated)
     }
 
     @Test
     fun builderCreatesCorrectField() {
         val fieldElement = field()
-        val field = Field(fieldElement)
+        val field = Field(fieldElement, emptyMap())
 
         val annotations = ImmutableMap.of<String, String>()
         val thriftType = mock(ThriftType::class.java)
@@ -147,15 +146,6 @@ class FieldTest {
 
         assertEquals(builderField.annotations, annotations)
         assertEquals(builderField.type, thriftType)
-    }
-
-    @Test
-    @Ignore
-    fun toBuilderCreatesCorrectField() {
-        val fieldElement = mock(FieldElement::class.java)
-        val field = Field(fieldElement)
-
-        assertEquals(field.toBuilder().build(), field)
     }
 
     private fun annotation(name: String): AnnotationElement {


### PR DESCRIPTION
UserType and Constant both had equivalent implementations for namespace building, storage, and querying.  This commit folds both into `UserElementMixin`.  In the process, constructors for all `UserElements` were reworked and simplified, sometimes greatly.  As a consequence, `ConstantTest` no longer needs reflection.

Fixes #182