### PR TITLE
Convert ConstValueElement to a sealed class

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -38,6 +38,8 @@ import com.microsoft.thrifty.schema.StructType
 import com.microsoft.thrifty.schema.ThriftType
 import com.microsoft.thrifty.schema.TypedefType
 import com.microsoft.thrifty.schema.UserType
+import com.microsoft.thrifty.schema.parser.ListValueElement
+import com.microsoft.thrifty.schema.parser.MapValueElement
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ArrayTypeName
 import com.squareup.javapoet.ClassName
@@ -883,7 +885,7 @@ class ThriftyCodeGenerator {
                 }
 
                 override fun visitList(listType: ListType) {
-                    if (constant.value.getAsList().isEmpty()) {
+                    if ((constant.value as ListValueElement).value.isEmpty()) {
                         field.initializer("\$T.emptyList()", TypeNames.COLLECTIONS)
                     } else {
                         initCollection("list", "unmodifiableList")
@@ -891,7 +893,7 @@ class ThriftyCodeGenerator {
                 }
 
                 override fun visitSet(setType: SetType) {
-                    if (constant.value.getAsList().isEmpty()) {
+                    if ((constant.value as ListValueElement).value.isEmpty()) {
                         field.initializer("\$T.emptySet()", TypeNames.COLLECTIONS)
                     } else {
                         initCollection("set", "unmodifiableSet")
@@ -899,7 +901,7 @@ class ThriftyCodeGenerator {
                 }
 
                 override fun visitMap(mapType: MapType) {
-                    if (constant.value.getAsMap().isEmpty()) {
+                    if ((constant.value as MapValueElement).value.isEmpty()) {
                         field.initializer("\$T.emptyMap()", TypeNames.COLLECTIONS)
                     } else {
                         initCollection("map", "unmodifiableMap")

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ConstValueElement.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ConstValueElement.kt
@@ -27,137 +27,87 @@ import com.microsoft.thrifty.schema.Location
  * default value.
  *
  * @property location The location of the text corresponding to this element.
- * @property kind The kind of constant value this is - integer, real, list, identifier, etc.
  * @property thriftText The actual Thrift text comprising this const value.
- * @property value The parsed value itself.  Will be of a type dictated by the value's [kind].
  */
-// TODO: Convert this to a sealed class
-data class ConstValueElement(
-        val location: Location,
-        val kind: Kind,
-        val thriftText: String,
-        val value: Any
-) {
-    val isInt: Boolean
-        get() = kind == Kind.INTEGER
+sealed class ConstValueElement {
+    abstract val location: Location
+    abstract val thriftText: String
+}
 
-    val isDouble: Boolean
-        get() = kind == Kind.DOUBLE
+/**
+ * An integer constant value.
+ *
+ * @property value The value, as a [Long].
+ */
+data class IntValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: Long
+) : ConstValueElement() {
+    override fun toString(): String = "$value"
+}
 
-    val isString: Boolean
-        get() = kind == Kind.STRING
+/**
+ * A floating-point constant value.
+ *
+ * @property value The value, as a [Double].
+ */
+data class DoubleValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: Double
+) : ConstValueElement() {
+    override fun toString(): String = "$value"
+}
 
-    val isIdentifier: Boolean
-        get() = kind == Kind.IDENTIFIER
+/**
+ * A string constant.
+ *
+ * @property value The value, as a [String].
+ */
+data class LiteralValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: String
+) : ConstValueElement() {
+    override fun toString(): String = value
+}
 
-    val isList: Boolean
-        get() = kind == Kind.LIST
+/**
+ * An identifier constant, such as an enum name or a const reference.
+ *
+ * @property value The identifier, as a [String].
+ */
+data class IdentifierValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: String
+) : ConstValueElement() {
+    override fun toString(): String = value
+}
 
-    val isMap: Boolean
-        get() = kind == Kind.MAP
+/**
+ * A list constant.
+ *
+ * @property value The value, as a [List].
+ */
+data class ListValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: List<ConstValueElement>
+) : ConstValueElement() {
+    override fun toString(): String = "$value"
+}
 
-    fun getAsInt(): Int {
-        check(isInt) { "Cannot convert to int; kind=$kind" }
-        return (value as Long).toInt()
-    }
-
-    fun getAsLong(): Long {
-        check(isInt) { "Cannot convert to long; kind=$kind" }
-        return value as Long
-    }
-
-    fun getAsDouble(): Double {
-        check(isInt || isDouble) { "Cannot convert to double; kind=$kind" }
-        return when  {
-            isDouble -> value as Double
-            isInt -> getAsInt().toDouble()
-            else -> error("unpossible")
-        }
-    }
-
-    fun getAsString(): String {
-        check(isString || isIdentifier) { "Cannot convert to string; kind=$kind" }
-        return value as String
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun getAsList(): List<ConstValueElement> {
-        check(isList) { "Cannot convert to list; kind=$kind"}
-        return value as List<ConstValueElement>
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun getAsMap(): Map<ConstValueElement, ConstValueElement> {
-        check(isMap) { "Cannot convert to map; kind=$kind" }
-        return value as Map<ConstValueElement, ConstValueElement>
-    }
-
-    /**
-     * Defines the kinds of values representable as a [ConstValueElement].
-     */
-    enum class Kind {
-        /**
-         * Ye Olde Integer.
-         *
-         * Will actually be a [Long], at runtime.
-         */
-        INTEGER,
-
-        /**
-         * A 64-it floating-point number.
-         */
-        DOUBLE,
-
-        /**
-         * A quoted string.
-         */
-        STRING,
-
-        /**
-         * An unquoted string, naming some other Thrift entity.
-         */
-        IDENTIFIER,
-
-        /**
-         * A list of [ConstValueElements][ConstValueElement]
-         *
-         * It is assumed that all values in the list share the same type; this
-         * is not enforced by the parser.
-         */
-        LIST,
-
-        /**
-         * An key-value mapping of [ConstValueElements][ConstValueElement].
-         *
-         * It is assumed that all keys share the same type, and that all values
-         * also share the same type.  This is not enforced by the parser.
-         */
-        MAP,
-    }
-
-    companion object {
-        fun integer(location: Location, text: String, value: Long): ConstValueElement {
-            return ConstValueElement(location, Kind.INTEGER, text, value)
-        }
-
-        fun real(location: Location, text: String, value: Double): ConstValueElement {
-            return ConstValueElement(location, Kind.DOUBLE, text, value)
-        }
-
-        fun literal(location: Location, text: String, value: String): ConstValueElement {
-            return ConstValueElement(location, Kind.STRING, text, value)
-        }
-
-        fun identifier(location: Location, text: String, value: String): ConstValueElement {
-            return ConstValueElement(location, Kind.IDENTIFIER, text, value)
-        }
-
-        fun list(location: Location, text: String, value: List<ConstValueElement>): ConstValueElement {
-            return ConstValueElement(location, Kind.LIST, text, value.toList())
-        }
-
-        fun map(location: Location, text: String, value: Map<ConstValueElement, ConstValueElement>): ConstValueElement {
-            return ConstValueElement(location, Kind.MAP, text, value.toMap())
-        }
-    }
+/**
+ * A map constant.
+ *
+ * @property value The value, as a [Map].
+ */
+data class MapValueElement(
+        override val location: Location,
+        override val thriftText: String,
+        val value: Map<ConstValueElement, ConstValueElement>
+) : ConstValueElement() {
+    override fun toString(): String = "$value"
 }

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
@@ -690,7 +690,7 @@ class ThriftParserTest {
                                                 type = TypeElement.scalar(location.at(4, 6), "i16"),
                                                 name = "baz",
                                                 requiredness = Requiredness.DEFAULT,
-                                                constValue = ConstValueElement.integer(
+                                                constValue = IntValueElement(
                                                         location.at(4, 16),
                                                         "0x0FFF",
                                                         0xFFF)),
@@ -720,7 +720,7 @@ class ThriftParserTest {
                                 location = location.at(1, 1),
                                 type = TypeElement.scalar(location.at(1, 7), "i64"),
                                 name = "DefaultStatusCode",
-                                value = ConstValueElement.integer(location.at(1, 31), "200", 200)
+                                value = IntValueElement(location.at(1, 31), "200", 200)
                         )
                 )
         )
@@ -740,9 +740,9 @@ class ThriftParserTest {
                                 location = location.at(1, 1),
                                 type = TypeElement.scalar(location.at(1, 7), "i64", null),
                                 name = "Yuuuuuge",
-                                value = ConstValueElement.integer(
+                                value = IntValueElement(
                                         location = location.at(1, 22),
-                                        text = "0xFFFFFFFFFF",
+                                        thriftText = "0xFFFFFFFFFF",
                                         value = 0xFFFFFFFFFFL
                                 )
                         )
@@ -763,14 +763,14 @@ class ThriftParserTest {
                         location = location.at(1, 7),
                         elementType = TypeElement.scalar(location.at(1, 12), "string")),
                 name = "Names",
-                value = ConstValueElement.list(
+                value = ListValueElement(
                         location = location.at(1, 28),
-                        text = "[\"foo\"\"bar\",\"baz\";\"quux\"]",
+                        thriftText = "[\"foo\"\"bar\",\"baz\";\"quux\"]",
                         value = listOf(
-                                ConstValueElement.literal(location.at(1, 29), "\"foo\"", "foo"),
-                                ConstValueElement.literal(location.at(1, 35), "\"bar\"", "bar"),
-                                ConstValueElement.literal(location.at(1, 42), "\"baz\"", "baz"),
-                                ConstValueElement.literal(location.at(1, 49), "\"quux\"", "quux"))))
+                                LiteralValueElement(location.at(1, 29), "\"foo\"", "foo"),
+                                LiteralValueElement(location.at(1, 35), "\"bar\"", "bar"),
+                                LiteralValueElement(location.at(1, 42), "\"baz\"", "baz"),
+                                LiteralValueElement(location.at(1, 49), "\"quux\"", "quux"))))
 
         val expected = ThriftFileElement(
                 location = location,
@@ -795,15 +795,15 @@ class ThriftParserTest {
                         keyType = TypeElement.scalar(location.at(1, 11), "string", null),
                         valueType = TypeElement.scalar(location.at(1, 19), "string", null)),
                 name = "Headers",
-                value = ConstValueElement.map(
+                value = MapValueElement(
                         location = location.at(1, 37),
-                        text = "{\"foo\":\"bar\",\"baz\":\"quux\";}",
+                        thriftText = "{\"foo\":\"bar\",\"baz\":\"quux\";}",
                         value = mapOf(
-                                ConstValueElement.literal(location.at(2, 3), "\"foo\"", "foo") to
-                                ConstValueElement.literal(location.at(2, 10), "\"bar\"", "bar"),
+                                LiteralValueElement(location.at(2, 3), "\"foo\"", "foo") to
+                                LiteralValueElement(location.at(2, 10), "\"bar\"", "bar"),
 
-                                ConstValueElement.literal(location.at(3, 3), "\"baz\"", "baz") to
-                                ConstValueElement.literal(location.at(3, 10), "\"quux\"", "quux"))))
+                                LiteralValueElement(location.at(3, 3), "\"baz\"", "baz") to
+                                        LiteralValueElement(location.at(3, 10), "\"quux\"", "quux"))))
 
         val expected = ThriftFileElement(
                 location = location,
@@ -834,7 +834,7 @@ class ThriftParserTest {
                                                 fieldId = 100,
                                                 type = TypeElement.scalar(location.at(2, 8), "i32"),
                                                 name = "num",
-                                                constValue = ConstValueElement.integer(location.at(2, 18), "1", 1)
+                                                constValue = IntValueElement(location.at(2, 18), "1", 1)
                                         )
                                 )
                         )
@@ -1231,7 +1231,7 @@ class ThriftParserTest {
         """.trimIndent()
 
         val constants = parse(thrift).constants
-        assertThat(constants.single().value.getAsDouble(), equalTo(2.0))
+        assertThat((constants.single().value as IntValueElement).value, equalTo(2L))
     }
 
     companion object {


### PR DESCRIPTION
Usually I say "if it ain't broke, don't fix it", but in this case the improved type-safety is worth it.  ConstValueElement was effectively a variant type with a bunch of subtype-specific accessors on it.  By making it a sealed type, the compiler helps ensure that we're using the type that we think we have.