### PR TITLE
Change command-line flags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     version VERSION
 
     project.ext {
-        kotlin_version = '1.2.51'
+        kotlin_version = '1.2.60'
 
         libraries = [
                 clikt: [

--- a/thrifty-compiler/build.gradle
+++ b/thrifty-compiler/build.gradle
@@ -59,7 +59,7 @@ task compileTestCase(type: Exec) {
     dependsOn jarTask
 
     executable 'java'
-    args = ['-jar', jarTask.archivePath.absolutePath, "--use-java-style-names", "--out=$projectDir/build/generated-src/gen/java", "$projectDir/TestThrift.thrift"]
+    args = ['-jar', jarTask.archivePath.absolutePath, "--name-style=java", "--out=$projectDir/build/generated-src/gen/java", "$projectDir/TestThrift.thrift"]
 }
 
 afterEvaluate {

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -53,6 +53,10 @@ import java.util.ArrayList
  * [--list-type=java.util.ArrayList]
  * [--set-type=java.util.HashSet]
  * [--map-type=java.util.HashMap]
+ * [--lang=[java|kotlin]]
+ * [--kt-file-per-type]
+ * [--parcelable]
+ * [--use-android-annotations]
  * file1.thrift
  * file2.thrift
  * ...
@@ -86,7 +90,10 @@ class ThriftyCompiler {
         KOTLIN
     }
 
-    private val cli = object : CliktCommand(name = "thrifty-compiler") {
+    private val cli = object : CliktCommand(
+            name = "thrifty-compiler",
+            help = "Generate Java or Kotlin code from .thrift files"
+    ) {
         val outputDirectory: Path by option("-o", "--out", help = "the output directory for generated files")
                 .path(fileOkay = false, folderOkay = true)
                 .required()
@@ -96,10 +103,13 @@ class ThriftyCompiler {
                 .path(exists = true, folderOkay = true, fileOkay = false)
                 .multiple()
 
-        val language: Language? by option("-l", "--lang", help = "the target language for generated code")
+        val language: Language? by option(
+                        "-l", "--lang", help = "the target language for generated code.  Default is java.")
                 .choice("java" to Language.JAVA, "kotlin" to Language.KOTLIN)
 
-        val nameStyle: FieldNamingPolicy by option("--name-style", "Format style for generated names.  Default ")
+        val nameStyle: FieldNamingPolicy by option(
+                        "--name-style",
+                        help = "Format style for generated names.  Default is to leave names unaltered.")
                 .choice("default" to FieldNamingPolicy.DEFAULT, "java" to FieldNamingPolicy.JAVA)
                 .default(FieldNamingPolicy.DEFAULT)
 

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -75,7 +75,7 @@ task kompileTestThrift(type: Exec) {
     dependsOn jarTask
 
     executable 'java'
-    args = ['-jar', jarTask.archivePath.absolutePath, "--out=$projectDir/build/generated-src/thrifty/kotlin", "--kotlin", "$projectDir/ClientThriftTest.thrift"]
+    args = ['-jar', jarTask.archivePath.absolutePath, "--out=$projectDir/build/generated-src/thrifty/kotlin", "--lang=kotlin", "$projectDir/ClientThriftTest.thrift"]
 }
 
 compileTestKotlin {


### PR DESCRIPTION
Instead of `--emit-kotlin`, we're adding a `--lang` option defaulting to Java.  Instead of `-use-java-style-names`, we're adding `--name-style` defaulting to, well, "default", but that can also be "java" (or potentially other styles as well).

This change also attempts to infer language if it is unspecified - in this case, if `--kt-file-per-type` is specified, but `--lang` is not, we assume that `--lang=kotlin` was intended.

Fixes #209

#209 envisioned a bigger revamp of the CLI, but on further thought we don't need to go to such lengths.  Just providing options (instead of boolean flags) for a few params and introducing `--lang` are enough to keep the CLI reasonable.