### PR TITLE
Fix DoubleValidator support for constants

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
@@ -212,8 +212,9 @@ class Constant private constructor (
                                 "Expected a value of type ${expected.name}, but got ${constant.type.name}")
                     }
                 }
+
+                else -> throw IllegalStateException("Expected a value of type DOUBLE but got $valueElement")
             }
-            throw IllegalStateException("Expected a value of type DOUBLE but got $valueElement")
         }
     }
 


### PR DESCRIPTION
The previous code would still throw IllegalStateException even if a
IdentifierValueElement successfully validated as a correctly-typed
constant.

Fix that by moving the failure case into an `else` clause on the `when`
statement instead of making it the default case for the entire function.

Alternatively, a `return` could be added to the IdentifierValueElement
case, but that's not as idiomatic, and the proposed style matches the
other validators.

This change also adds full test coverage for the DOUBLE validator.