### PR TITLE
Avoid scope collisions when reading map values

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/GenerateReaderVisitor.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/GenerateReaderVisitor.kt
@@ -204,9 +204,11 @@ internal open class GenerateReaderVisitor(
             mapType.keyType.accept(this)
             nameStack.pop()
 
-            nameStack.push(value)
-            mapType.valueType.accept(this)
-            nameStack.pop()
+            pushScope {
+                nameStack.push(value)
+                mapType.valueType.accept(this)
+                nameStack.pop()
+            }
 
             read.addStatement("\$N.put(\$N, \$N)", nameStack.peek(), key, value)
 

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -433,6 +433,41 @@ class ThriftyCodeGeneratorTest {
     }
 
     @Test
+    fun mapsWithEnumKeysAndValues () {
+        val thrift = """
+            namespace java maps.enums
+
+            enum Key { KEY }
+            enum Value { VALUE }
+
+            struct HasMap {
+                1: optional map<Key, Value> m
+            }
+        """
+
+        val expected = """
+              for (int i0 = 0; i0 < mapMetadata0.size; ++i0) {
+                int i32_1 = protocol.readI32();
+                maps.enums.Key key0 = maps.enums.Key.findByValue(i32_1);
+                if (key0 == null) {
+                  throw new ThriftException(ThriftException.Kind.PROTOCOL_ERROR, "Unexpected value for enum-type Key: " + i32_1);
+                }
+                int i32_2 = protocol.readI32();
+                maps.enums.Value value0 = maps.enums.Value.findByValue(i32_2);
+                if (value0 == null) {
+                  throw new ThriftException(ThriftException.Kind.PROTOCOL_ERROR, "Unexpected value for enum-type Value: " + i32_2);
+                }
+                value.put(key0, value0);
+              }
+            """
+
+        val thriftFile = tmp.newFile("maps_enums.thrift")
+        val javaFile = compile(thriftFile, thrift)[2]
+
+        assertThat(javaFile.toString()).contains(expected)
+    }
+
+    @Test
     fun structsWithSigilsInJavadoc() {
         val thrift = """
             namespace java sigils.structs


### PR DESCRIPTION
Previously, the generated Java code for reading maps would use the same
scope for both the key and the value. If both the key and value were of
the same primitive type (e.g. `map<enum, enum>`), the two intermediate
variable names would clash because they're derived from the same type
and scope (e.g. `i32_1` and `i32_1`).

This change pushes the value reading code into its own nested scope to
avoid that collision (e.g. `i32_1` and `i32_2`).