### PR TITLE
Fix scope collisions between enums in maps

### DIFF
--- a/thrifty-integration-tests/ClientThriftTest.thrift
+++ b/thrifty-integration-tests/ClientThriftTest.thrift
@@ -427,3 +427,8 @@ const map<string, map<string, map<i32, i32>>> HEINOUS = {
 }
 
 const list<set<map<string, i32>>> ALL_THE_COLLECTIONS = [[], [{"foo": 1, "bar": 2}]]
+
+struct MapsOfEnums {
+  1: map<Numberz, Numberz> mapOne;
+  2: map<list<Numberz>, Numberz> mapTwo;
+}

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -965,14 +965,12 @@ class KotlinCodeGenerator(
             }
 
             override fun visitEnum(enumType: EnumType) {
-                val codeName = "code$scope"
-                block.addStatement("val $codeName = protocol.readI32()")
-                block.addStatement("val $name = %T.findByValue($codeName)", enumType.typeName)
-                block.beginControlFlow("if ($name == null)")
-                block.addStatement("throw %T(%T.PROTOCOL_ERROR, \"Unexpected value for enum type %T: \$$codeName\")",
+                block.beginControlFlow("val $name = protocol.readI32().let")
+                block.addStatement(
+                        "%1T.findByValue(it) ?: throw %2T(%3T.PROTOCOL_ERROR, \"Unexpected value for enum type %1T: \$it\")",
+                        enumType.typeName,
                         ThriftException::class,
-                        ThriftException.Kind::class,
-                        enumType.typeName)
+                        ThriftException.Kind::class)
                 block.endControlFlow()
             }
 


### PR DESCRIPTION
In #217, we fixed broken generated Java for maps of enum types.  As it happens, the same thing was broken in Kotlin.  This commit fixes it.