### PR TITLE
Fix FramedTransport reads spanning >1 frame

### DIFF
--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/transport/FramedTransport.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/transport/FramedTransport.java
@@ -55,7 +55,9 @@ public class FramedTransport extends Transport {
         }
 
         int toRead = Math.min(count, remainingBytes);
-        return inner.read(buffer, offset, toRead);
+        int numRead = inner.read(buffer, offset, toRead);
+        remainingBytes -= numRead;
+        return numRead;
     }
 
     private void readHeader() throws IOException {

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/transport/FramedTransportTest.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/transport/FramedTransportTest.java
@@ -71,4 +71,20 @@ public class FramedTransportTest {
         assertThat(target.readInt(), is(37));
         assertThat(target.readUtf8(), is("this text contains thirty-seven bytes"));
     }
+
+    @Test
+    public void readsSpanningMultipleFrames() throws Exception {
+        Buffer buffer = new Buffer();
+        buffer.writeInt(6);
+        buffer.writeUtf8("abcdef");
+        buffer.writeInt(4);
+        buffer.writeUtf8("ghij");
+
+        FramedTransport transport = new FramedTransport(new BufferTransport(buffer));
+
+        byte[] readBuffer = new byte[10];
+        assertThat(transport.read(readBuffer, 0, 10), is(6));
+        assertThat(transport.read(readBuffer, 6, 4), is(4));
+        assertThat(new String(readBuffer, Charsets.UTF_8), is("abcdefghij"));
+    }
 }


### PR DESCRIPTION
I can't believe that this has been utterly broken since 2015.  I guess no Thrifty users use non-blocking transports?