### PR TITLE
Add missing call to protocol.readMessageEnd()

### DIFF
--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
@@ -406,4 +406,14 @@ class KotlinConformanceTest(
         error.errorCode shouldBe 2002
         error.struct_thing?.string_thing shouldBe "This is an Xception2"
     }
+
+    @Test fun testConsecutiveCalls() {
+        testStruct()
+        testStruct()
+        testExceptionNormalError()
+        testByte()
+        testBool()
+        testI32()
+        testI64()
+    }
 }

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/ClientBase.java
@@ -20,6 +20,7 @@
  */
 package com.microsoft.thrifty.service;
 
+import com.microsoft.thrifty.Struct;
 import com.microsoft.thrifty.ThriftException;
 import com.microsoft.thrifty.protocol.MessageMetadata;
 import com.microsoft.thrifty.protocol.Protocol;
@@ -149,7 +150,17 @@ public class ClientBase implements Closeable {
                             + " but received " + metadata.name);
         }
 
-        return call.receive(protocol, metadata);
+        try {
+            Object result = call.receive(protocol, metadata);
+            protocol.readMessageEnd();
+            return result;
+        } catch (Exception e) {
+            if (e instanceof Struct) {
+                // Business as usual
+                protocol.readMessageEnd();
+            }
+            throw e;
+        }
     }
 
     static class ServerException extends Exception {


### PR DESCRIPTION
We've missed this since the beginning because BinaryProtocol and CompactProtocol both send and receive nothing for message end.  JsonProtocol, however, is sensitive to this.  Adding calls to `readMessageEnd()` for both normal and exceptional results fixes things.