### PR TITLE
 Upstreaming rendering tool for thrifty-schema

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/NamespaceScope.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/NamespaceScope.kt
@@ -28,7 +28,7 @@ package com.microsoft.thrifty.schema
  * by Thrift and so are included to retain fidelity.  Scopes relevant to
  * Thrifty are [ALL], [JAVA], and [KOTLIN].
  */
-enum class NamespaceScope(private val thriftName: String) {
+enum class NamespaceScope(internal val thriftName: String) {
     /**
      * Represents all languages; often used as a fallback value.
      */

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Schema.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Schema.kt
@@ -66,6 +66,13 @@ class Schema {
      */
     val services: List<ServiceType>
 
+    /**
+     * @return an [Iterable] of all [UserElements][UserElement] in this [Schema].
+     */
+    fun elements(): Iterable<UserElement> {
+        return structs + unions + exceptions + enums + constants + typedefs + services
+    }
+
     internal constructor(programs: Iterable<Program>) {
         val structs = mutableListOf<StructType>()
         val unions = mutableListOf<StructType>()

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/Include.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/Include.kt
@@ -1,0 +1,10 @@
+package com.microsoft.thrifty.schema.render
+
+/**
+ * Represents an include in a [ThriftSpec].
+ *
+ * @property path the path to the included file. Can be relative or absolute.
+ * @property namespace the namespace of this included file (used to differentiate this from the name space of the source file).
+ * @property relative a flag indicating whether or not this [path] is a relative path.
+ */
+data class Include internal constructor(val path: String, internal val namespace: String, val relative: Boolean)

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/Include.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/Include.kt
@@ -1,3 +1,23 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
 package com.microsoft.thrifty.schema.render
 
 /**

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/RenderingUtil.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/RenderingUtil.kt
@@ -1,0 +1,76 @@
+package com.microsoft.thrifty.schema.render
+
+import com.microsoft.thrifty.schema.*
+import java.io.File
+
+internal val NEWLINE = System.getProperty("line.separator")!!
+internal val DOUBLE_NEWLINE = "$NEWLINE$NEWLINE"
+
+/**
+ * Full file path for a given [UserElement].
+ */
+internal inline val UserElement.filepath: String
+    get() = "${location.base}${File.separator}${location.path}"
+
+/**
+ * Full file path for a given [Location].
+ */
+internal inline val Location.filepath: String
+    get() = "$base${File.separator}$path"
+
+/**
+ * A string representation for a [Field's][Field] requiredness for rendering.
+ */
+internal val Field.requiredness: String
+    get() {
+        return when {
+            required -> " required"
+            optional -> " optional"
+            else -> ""
+        }
+    }
+
+/**
+ * Unpacks a [ThriftType] as needed, handling collection types.
+ *
+ * @return the unpacked [ThriftType].
+ */
+internal fun ThriftType.unpack(): Set<ThriftType> {
+    return when {
+        this is ListType -> setOf(elementType)
+        this is SetType -> setOf(elementType)
+        this is MapType -> setOf(keyType, valueType)
+        else -> setOf(this)
+    }
+}
+
+/**
+ * Invokes the action from all the elements separated using [separator] and using the given [prefix] and [postfix] if supplied.
+ *
+ * If the collection could be huge, you can specify a non-negative value of [limit], in which case only the first [limit]
+ * elements will be appended, followed by the [truncated] string (which defaults to "...").
+ *
+ * This is slightly modified form of [Iterable.joinTo] but does not transform each element to a string. Instead the buffer
+ * is passed to the [action] so that it can run its own additions to the [buffer].
+ */
+internal fun <T, A : Appendable> Iterable<T>.joinEachTo(
+    buffer: A,
+    separator: CharSequence = ", ",
+    prefix: CharSequence = "",
+    postfix: CharSequence = "",
+    limit: Int = -1,
+    truncated: CharSequence = "...",
+    action: ((A, T) -> Unit)? = null
+): A {
+    buffer.append(prefix)
+    var count = 0
+    for (element in this) {
+        if (++count > 1) buffer.append(separator)
+        if (limit < 0 || count <= limit) {
+            action?.invoke(buffer, element)
+        } else break
+    }
+    if (limit in 0..(count - 1)) buffer.append(truncated)
+    buffer.append(postfix)
+    return buffer
+}

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/RenderingUtil.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/RenderingUtil.kt
@@ -1,3 +1,23 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
 package com.microsoft.thrifty.schema.render
 
 import com.microsoft.thrifty.schema.*

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
@@ -1,0 +1,477 @@
+@file:JvmName("SchemaRendering")
+
+package com.microsoft.thrifty.schema.render
+
+import com.microsoft.thrifty.schema.*
+import com.microsoft.thrifty.schema.NamespaceScope.JAVA
+import java.io.File
+
+/*
+ * Rendering utilities for Thrifty elements. These render Thrifty elements back to well-formatted
+ * spec notation.
+ */
+
+/**
+ * Renders a potentially multi-file schema as a [Set] of [ThriftSpec]s. This will resolve `include`s
+ * for the files while also collecting namespaces.
+ *
+ * @param relativizeIncludes a flag to indicate whether or not to relativize include statements.
+ * Default is `true`
+ * @param namespaceResolver a lambda function to result namespaces for given [UserType]s. Default
+ * is to just use its Java namespace, but can be useful to configure it to look for alternate
+ * namespaces (such as when performing package name preprocessing). This parameter will likely be
+ * removed in the future.
+ * @param minimumPrefix an optional "minimum prefix" to require if [relativizeIncludes] is true.
+ * Normally when relativizing, paths are shortened to remove their combined common prefix. This can
+ * be specified to ensure that a minimumPrefix is kept for reference beyond the scope of this
+ * function. Example: `minPrefix = "foo/bar"` -> common prefix with `bar/baz` will be `foo/bar/baz`.
+ * @return the rendered [Set] of [ThriftSpec]s.
+ */
+fun Schema.multiFileRender(
+    relativizeIncludes: Boolean = true,
+    namespaceResolver: (UserType) -> String = { it.namespaces[JAVA]!! },
+    minimumPrefix: String? = null
+): Set<ThriftSpec> {
+    // If relativizing, deduce the common prefix of all the file paths to know the "root" of their
+    // directory
+    val commonPathPrefix = if (relativizeIncludes) {
+        elements()
+            .asSequence()
+            .map(UserElement::filepath)
+            .reduce { currentPrefix, nextLocation ->
+                currentPrefix.commonPrefixWith(nextLocation)
+            }
+            .let { calculatedPrefix ->
+                minimumPrefix?.let { minPrefix ->
+                    check(calculatedPrefix.contains(minPrefix)) {
+                        "Calculated common prefix for files doesn't contain the specified minimum prefix!\nCalculated: $calculatedPrefix\nMinimum: $minPrefix"
+                    }
+                    calculatedPrefix.substringBefore(minPrefix)
+                } ?: calculatedPrefix
+            }
+            .let {
+                if (it.endsWith(".thrift")) {
+                    // We only have one file. Back it up to the directory name for sanity
+                    it.substringBeforeLast(File.separator)
+                } else it
+            }
+    } else ""
+    return elements()
+        .groupBy(UserElement::filepath)
+        .mapKeys { it.key.removePrefix(commonPathPrefix) }
+        .mapTo(LinkedHashSet()) { (filePath, sourceElements) ->
+            val elements =
+                sourceElements.filter { it.filepath.removePrefix(commonPathPrefix) == filePath }
+            val namespaces = elements.filterIsInstance<UserType>()
+                .map(UserType::namespaces)
+            check(namespaces.distinct().size == 1) {
+                "Multiple namespaces! $namespaces"
+            }
+            val realNamespaces = namespaces.first()
+            val fileSchema = toBuilder()
+                .exceptions(elements.filterIsInstance<StructType>().filter(StructType::isException))
+                .services(elements.filterIsInstance<ServiceType>())
+                .structs(elements.filterIsInstance<StructType>().filter { !it.isUnion && !it.isException })
+                .typedefs(elements.filterIsInstance<TypedefType>())
+                .enums(elements.filterIsInstance<EnumType>())
+                .unions(elements.filterIsInstance<StructType>().filter(StructType::isUnion))
+                .build()
+
+            val sourceFile = File(filePath)
+            val includes = elements
+                .flatMap { element ->
+                    when (element) {
+                        is StructType -> {
+                            element.fields
+                                .flatMap {
+                                    it.type
+                                        .unpack()
+                                }
+                        }
+                        is ServiceType -> {
+                            element.methods
+                                .flatMap { method ->
+                                    (method.run { exceptions + parameters })
+                                        .flatMap {
+                                            it.type
+                                                .unpack()
+                                        } + method.returnType.unpack()
+                                }
+                        }
+                        is TypedefType -> element.oldType.unpack()
+                        else -> emptySet()
+                    }
+                }
+                .filterIsInstance<UserType>()
+                .distinctBy(UserType::filepath)
+                .filter { it.filepath.removePrefix(commonPathPrefix) != filePath }
+                .map { it to it.filepath.removePrefix(commonPathPrefix) }
+                .run {
+                    if (relativizeIncludes) {
+                        map {
+                            it.first to File(it.second).toRelativeString(sourceFile)
+                                .removePrefix("../")
+                                .run {
+                                    if (startsWith("../")) {
+                                        this
+                                    } else {
+                                        "./$this"
+                                    }
+                                }
+                        }
+                    } else this
+                }
+                .map {
+                    Include(
+                        path = it.second,
+                        namespace = namespaceResolver(it.first),
+                        relative = relativizeIncludes
+                    )
+                }
+
+            return@mapTo ThriftSpec(
+                filePath = filePath,
+                namespaces = realNamespaces,
+                includes = includes,
+                schema = fileSchema
+            )
+        }
+}
+
+/**
+ * @return the rendered form of this [Schema].
+ */
+fun Schema.render() = renderTo(StringBuilder()).toString()
+
+/**
+ * Renders this [Schema] into a given [buffer].
+ *
+ * @return the [buffer] for chaining convenience.
+ */
+@Suppress("RemoveExplicitTypeArguments") // False positive
+fun <A : Appendable> Schema.renderTo(buffer: A) = buffer.apply {
+    if (typedefs.isNotEmpty()) {
+        typedefs.sortedBy(TypedefType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, typedef ->
+                typedef.renderTo<A>(buffer)
+            }
+    }
+    if (enums.isNotEmpty()) {
+        enums.sortedBy(EnumType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, enum ->
+                enum.renderTo<A>(buffer)
+            }
+    }
+    if (structs.isNotEmpty()) {
+        structs.sortedBy(StructType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, struct ->
+                struct.renderTo<A>(buffer)
+            }
+    }
+    if (unions.isNotEmpty()) {
+        unions.sortedBy(StructType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, struct ->
+                struct.renderTo<A>(buffer)
+            }
+    }
+    if (exceptions.isNotEmpty()) {
+        exceptions.sortedBy(StructType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, struct ->
+                struct.renderTo<A>(buffer)
+            }
+    }
+    if (services.isNotEmpty()) {
+        services.sortedBy(ServiceType::name)
+            .joinEachTo(
+                buffer = buffer,
+                separator = DOUBLE_NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, service ->
+                service.renderTo<A>(buffer)
+            }
+    }
+
+}
+
+/**
+ * @return the rendered form of this [UserElement].
+ */
+fun UserElement.renderElement(indent: String = "  ") =
+    renderElementTo(StringBuilder(), indent).toString()
+
+/**
+ * Renders this [UserElement] into a given [buffer].
+ *
+ * @return the [buffer] for chaining convenience.
+ */
+fun <A : Appendable> UserElement.renderElementTo(buffer: A, indent: String = "  "): A {
+    @Suppress("RemoveExplicitTypeArguments") // False positive
+    when (this) {
+        is UserType -> renderTo<A>(buffer)
+        is Field -> renderTo<A>(buffer, indent)
+        is ServiceMethod -> renderTo<A>(buffer, indent)
+        is EnumMember -> renderTo<A>(buffer, indent)
+        is Constant -> renderTo<A>(buffer)
+        else -> throw IllegalArgumentException("Unsupported UserElement type: $this")
+    }
+    return buffer
+}
+
+/**
+ * @return the rendered form of this [UserType].
+ */
+fun UserType.render(): String = renderTo(StringBuilder()).toString()
+
+/**
+ * Renders this [UserType] into a given [buffer].
+ *
+ * @return the [buffer] for chaining convenience.
+ */
+fun <A : Appendable> UserType.renderTo(buffer: A): A {
+    // Doesn't follow the usual buffer.apply function body pattern because type checking falls over
+    @Suppress("RemoveExplicitTypeArguments") // False positive
+    when (this) {
+        is TypedefType -> renderTo<A>(buffer)
+        is EnumType -> renderTo<A>(buffer)
+        is StructType -> renderTo<A>(buffer)
+        is ServiceType -> renderTo<A>(buffer)
+        else -> throw IllegalArgumentException("Unrecognized UserType: $this")
+    }
+    return buffer
+}
+
+private fun <A : Appendable> TypedefType.renderTo(buffer: A) = buffer.apply {
+    renderJavadocTo(buffer)
+    append("typedef ")
+    oldType.renderTypeTo(buffer, location)
+    oldType.annotations
+        .renderTo(buffer)
+    append(" ", name)
+    renderAnnotationsTo(buffer, indent = " ")
+}
+
+private fun <A : Appendable> StructType.renderTo(buffer: A) = buffer.apply {
+    renderJavadocTo(buffer)
+    val type = when {
+        isException -> "exception"
+        isUnion -> "union"
+        else -> "struct"
+    }
+    append(type, " ", name, " {")
+    appendln()
+    fields
+        .joinEachTo(buffer, NEWLINE) { _, field ->
+            field.renderElementTo(buffer)
+        }
+    appendln()
+    append("}")
+    renderAnnotationsTo(buffer)
+}
+
+private fun <A : Appendable> EnumType.renderTo(buffer: A) = buffer.apply {
+    renderJavadocTo(buffer)
+    append("enum ", name, " {")
+    appendln()
+    members.joinEachTo(buffer, ",$NEWLINE") { _, member ->
+        member.renderElementTo(buffer)
+    }
+    appendln()
+    append("")
+    append("}")
+    renderAnnotationsTo(buffer)
+}
+
+private fun <A : Appendable> ServiceType.renderTo(buffer: A) = buffer.apply {
+    renderJavadocTo(buffer)
+    append("service ", name, " {")
+    appendln()
+    methods.joinEachTo(buffer = buffer, separator = DOUBLE_NEWLINE) { _, method ->
+        method.renderElementTo(buffer)
+    }
+    appendln()
+    append("}")
+    renderAnnotationsTo(buffer)
+}
+
+private fun <A : Appendable> Field.renderTo(buffer: A, indent: String = "  ") = buffer.apply {
+    renderJavadocTo(buffer, indent)
+    append(indent, id.toString(), ":", requiredness, " ")
+    type.renderTypeTo(buffer, location)
+    if (type !is UserType) type.annotations.renderTo(buffer)
+    append(" ", name)
+    renderAnnotationsTo(buffer, indent)
+}
+
+private fun <A : Appendable> ServiceMethod.renderTo(buffer: A, indent: String = "  ") =
+    buffer.apply {
+        renderJavadocTo(buffer, indent)
+        append(indent)
+        returnType.renderTypeTo(buffer, location)
+        append(" ", name)
+        if (parameters.isEmpty()) {
+            append("()")
+        } else {
+            parameters
+                .joinEachTo(
+                    buffer = buffer,
+                    separator = ",$NEWLINE",
+                    prefix = "($NEWLINE",
+                    postfix = "$NEWLINE$indent)"
+                ) { _, param ->
+                    param.renderTo(buffer, "$indent  ")
+                }
+        }
+        if (exceptions.isNotEmpty()) {
+            appendln(" throws (")
+            exceptions
+                .joinEachTo(buffer = buffer, separator = ",$NEWLINE") { _, param ->
+                    param.renderTo(buffer, "$indent  ")
+                }
+            appendln()
+            append(indent, ")")
+        }
+        renderAnnotationsTo(buffer, indent)
+    }
+
+private fun <A : Appendable> EnumMember.renderTo(buffer: A, indent: String = "  ") = buffer.apply {
+    renderJavadocTo(buffer, indent)
+    append(indent, name, " = ", value.toString())
+    renderAnnotationsTo(buffer)
+}
+
+private fun <A : Appendable> Constant.renderTo(buffer: A) = buffer.apply {
+    renderJavadocTo(buffer)
+    append("const ")
+    type.renderTypeTo(buffer, location)
+    append(" ")
+    type.annotations
+        .renderTo(buffer)
+    append(" ", name, " = ", value.thriftText)
+    renderAnnotationsTo(buffer)
+}
+
+/**
+ * Renders a thrift type by its name, possibly prefixing with the program name if not the same
+ * location as [source].
+ */
+private fun <A : Appendable> ThriftType.renderTypeTo(buffer: A, source: Location): A {
+    // Doesn't follow the usual buffer.apply function body pattern because type checking falls over
+    when {
+        this is UserType && source.filepath != location.filepath -> {
+            buffer.apply {
+                append(location.programName)
+                append(".")
+                append(name)
+            }
+        }
+        this is SetType -> {
+            buffer.apply {
+                append("set<")
+                elementType.renderTypeTo(buffer, source)
+                append(">")
+            }
+        }
+        this is ListType -> {
+            buffer.apply {
+                append("list<")
+                elementType.renderTypeTo(buffer, source)
+                append(">")
+            }
+        }
+        this is MapType -> {
+            buffer.apply {
+                append("map<")
+                keyType.renderTypeTo(buffer, source)
+                append(",")
+                valueType.renderTypeTo(buffer, source)
+                append(">")
+            }
+        }
+        else -> buffer.append(name)
+    }
+    return buffer
+}
+
+private fun <A : Appendable> UserElement.renderJavadocTo(buffer: A, indent: String = "") =
+    buffer.apply {
+        if (hasJavadoc) {
+            val docLines = documentation.trim()
+                .trim(Character::isSpaceChar)
+                .lines()
+            val isSingleLine = docLines.size == 1
+            if (isSingleLine) {
+                append(indent)
+                append("/* ")
+                append(docLines[0])
+                appendln(" */")
+            } else {
+                docLines.joinTo(
+                    buffer = buffer,
+                    separator = NEWLINE,
+                    prefix = "$indent/**$NEWLINE",
+                    postfix = "$NEWLINE$indent */$NEWLINE"
+                ) {
+                    "$indent * $it"
+                }
+            }
+        }
+    }
+
+private fun <A : Appendable> UserElement.renderAnnotationsTo(
+    buffer: A,
+    indent: String = "",
+    prefix: String = " "
+) = buffer.apply {
+    annotations.renderTo(buffer, indent, prefix)
+}
+
+private fun <A : Appendable> Map<String, String>.renderTo(
+    buffer: A,
+    indent: String = "",
+    prefix: String = " "
+) = buffer.apply {
+    when {
+        size == 1 -> {
+            append(prefix)
+            append("(")
+            val (key, value) = entries.first()
+            append(key)
+            append(" = ")
+            append("\"")
+            append(value.replace("\"", "\\\""))
+            append("\"")
+            append(")")
+        }
+        size > 1 -> {
+            append(prefix)
+            appendln("(")
+            entries
+                .sortedBy(Map.Entry<String, String>::key)
+                .joinTo(buffer = buffer, separator = ",$NEWLINE") { (key, value) ->
+                    "$indent  $key = \"${value.replace("\"", "\\\"")}\""
+                }
+            appendln()
+            append(indent, ")")
+        }
+    }
+}

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
@@ -1,3 +1,23 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
 @file:JvmName("SchemaRendering")
 
 package com.microsoft.thrifty.schema.render

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/ThriftSpec.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/ThriftSpec.kt
@@ -1,0 +1,65 @@
+package com.microsoft.thrifty.schema.render
+
+import com.microsoft.thrifty.schema.NamespaceScope
+import com.microsoft.thrifty.schema.Schema
+import java.io.File
+
+/**
+ * A representation of an individual thrift spec file.
+ *
+ * @property filePath the relative path of this file.
+ * @property namespaces the namespaces of this file.
+ * @property includes any includes this file declares.
+ * @property schema the [Schema] of elements contained within this file.
+ */
+data class ThriftSpec internal constructor(
+    val filePath: String,
+    val namespaces: Map<NamespaceScope, String>,
+    val includes: List<Include>,
+    val schema: Schema
+) {
+
+    /**
+     * The simple name of this file.
+     */
+    val name = File(filePath).nameWithoutExtension
+
+    /**
+     * @return a render of this file. This returns valid thrift that could be parsed back and yield
+     * an equivalent [Schema] to this spec's [schema].
+     */
+    fun render(fileComment: String? = null) = renderTo(StringBuilder(), fileComment).toString()
+
+    /**
+     * Renders this file to a given [buffer]. This returns valid thrift that could be parsed back and
+     * yield an equivalent [Schema] to this spec's [schema].
+     *
+     * @return the [buffer] for convenience chaining.
+     */
+    fun <A : Appendable> renderTo(buffer: A, fileComment: String? = null) = buffer.apply {
+        fileComment?.let {
+            append("// ", it)
+            appendln()
+            appendln()
+        }
+        if (namespaces.isNotEmpty()) {
+            namespaces.entries.joinEachTo(
+                buffer = buffer,
+                separator = NEWLINE,
+                postfix = DOUBLE_NEWLINE
+            ) { _, (key, value) ->
+                buffer.append("namespace ", key.thriftName, " ", value)
+            }
+        }
+        if (includes.isNotEmpty()) {
+            includes
+                .sortedBy(Include::path)
+                .joinEachTo(buffer,
+                    NEWLINE, postfix = DOUBLE_NEWLINE
+                ) { _, include ->
+                    buffer.append("include \"", include.path, "\"")
+                }
+        }
+        schema.renderTo(this)
+    }
+}

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/ThriftSpec.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/ThriftSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
 package com.microsoft.thrifty.schema.render
 
 import com.microsoft.thrifty.schema.NamespaceScope


### PR DESCRIPTION

This is an upstreaming of our internal renderer for thrifty-schema (and all its element types). This doesn't have any tests included because we don't have any currently, but surfaced up as a starting point :). It does work extremely well though.

High level API overview:
* `ThriftSpec` - represents a thrift spec file. It contains a `Schema` of elements within that spec, includes, namespaces, and the relative file path within the set of specs
* `Include` - represents an `include` statement in a `ThriftSpec`
* `SchemaRendering` - the main entry point for rendering. Can render individual elements or create a multi-file rendered representation of a multi-file `Schema`.