### PR TITLE
Add an --omit-file-comments command line flag

### DIFF
--- a/thrifty-compiler/README.md
+++ b/thrifty-compiler/README.md
@@ -22,6 +22,7 @@ Option | Description
 `--name-style=[default,java]` | Optional.  Specifies how Thrift field names should be represented in generated code.  `default` leaves names unchanged, while `java` converts them to `camelCase`.
 `--use-android-annotations` | Optional.  When given, Android Support Annotations will be added for generated fields (`@NonNull` and `@Nullable`).
 `--parcelable` | Optional.  Structs, unions, and exceptions will have implementations of Parcelable generated.
+`--omit-file-comments` | Optional.  When set, don't add file comments to generated files.
 `--list-type=[classname]` | A java.util.List implementation to be used wherever lists are instantiated in generated code.
 `--set-type=[classname]` | A java.util.Set implementation to be used wherever sets are instantiated in generated code.
 `--map-type=[classname]` | A java.util.Map implementation, as above.

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -57,6 +57,7 @@ import java.util.ArrayList
  * [--kt-file-per-type]
  * [--parcelable]
  * [--use-android-annotations]
+ * [--omit-file-comments]
  * file1.thrift
  * file2.thrift
  * ...
@@ -123,6 +124,10 @@ class ThriftyCompiler {
 
         val emitParcelable: Boolean by option("--parcelable",
                     help = "When set, generates Parcelable implementations for structs")
+                .flag(default = false)
+
+        val omitFileComments: Boolean by option("--omit-file-comments",
+                    help = "When set, don't add file comments to generated files")
                 .flag(default = false)
 
         val kotlinFilePerType: Boolean by option(
@@ -195,6 +200,7 @@ class ThriftyCompiler {
             }
 
             gen.emitAndroidAnnotations(emitNullabilityAnnotations)
+            gen.emitFileComment(!omitFileComments)
             gen.emitParcelable(emitParcelable)
 
             gen.generate(outputDirectory)


### PR DESCRIPTION
This optional command line flag can be set to disable file comments in
generated (Java) files. The Kotlin code generator doesn't appear to add
any file comments at this time.

See #233 