### PR TITLE
Only use base filename in constants' comments

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -864,7 +864,7 @@ class ThriftyCodeGenerator {
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
 
             if (constant.hasJavadoc) {
-                field.addJavadoc("\$L", constant.documentation + "\n\nGenerated from: " + constant.location + "\n")
+                field.addJavadoc("\$L", constant.documentation)
             }
 
             if (constant.isDeprecated) {

--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -864,7 +864,7 @@ class ThriftyCodeGenerator {
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
 
             if (constant.hasJavadoc) {
-                field.addJavadoc("\$L", constant.documentation)
+                field.addJavadoc("\$L", constant.documentation + "\n\nGenerated from: " + constant.location.path + " at " + constant.location.line + ":" + constant.location.column + "\n")
             }
 
             if (constant.isDeprecated) {

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -358,15 +358,12 @@ class ThriftyCodeGeneratorTest {
             const i32 INT = 12345
         """
 
-        val expectedFormat = """
+        val expected = """
             package sigils.consts;
 
             public final class Constants {
               /**
                * This comment has ${"$"}Dollar ${"$"}Signs
-               *
-               *
-               * Generated from: %s at 4:1
                */
               public static final int INT = 12345;
 
@@ -381,7 +378,6 @@ class ThriftyCodeGeneratorTest {
         val javaFile = compile(thriftFile, thrift)[0]
 
         val javaText = javaFile.toString()
-        val expected = String.format(expectedFormat, thriftFile.absolutePath)
 
         assertThat(javaText).isEqualTo(expected)
     }

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -358,12 +358,15 @@ class ThriftyCodeGeneratorTest {
             const i32 INT = 12345
         """
 
-        val expected = """
+        val expectedFormat = """
             package sigils.consts;
 
             public final class Constants {
               /**
                * This comment has ${"$"}Dollar ${"$"}Signs
+               *
+               *
+               * Generated from: %s at 4:1
                */
               public static final int INT = 12345;
 
@@ -378,6 +381,7 @@ class ThriftyCodeGeneratorTest {
         val javaFile = compile(thriftFile, thrift)[0]
 
         val javaText = javaFile.toString()
+        val expected = String.format(expectedFormat, thriftFile.name)
 
         assertThat(javaText).isEqualTo(expected)
     }


### PR DESCRIPTION
This line unfortunately included the local file system path that can
differ between individual systems. This isn't ideal for projects that
store these generated files in source control because is causes
unnecessary file differences.

See #233