### PR TITLE
Add @Nullable annotation to findByValue methods

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -997,6 +997,10 @@ class ThriftyCodeGenerator {
                 .addParameter(Int::class.javaPrimitiveType, "value")
                 .beginControlFlow("switch (value)")
 
+        if (emitAndroidAnnotations) {
+            fromCodeMethod.addAnnotation(TypeNames.NULLABLE)
+        }
+
         for (member in type.members) {
             val name = member.name
 

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -215,6 +215,28 @@ class ThriftyCodeGeneratorTest {
     }
 
     @Test
+    fun nullableEnumFindByValue() {
+        val thrift = """
+            namespace java enums
+
+            // a generated enum
+            enum BuildStatus {
+                OK = 0,
+                FAIL = 1
+            }
+        """
+
+        val schema = parse("enum_nullable.thrift", thrift)
+        val gen = ThriftyCodeGenerator(schema).emitAndroidAnnotations(true)
+        val javaFiles = gen.generateTypes()
+        val file = javaFiles[0]
+
+        val java = file.toString()
+
+        assertThat(java).contains("@Nullable\n  public static BuildStatus findByValue")
+    }
+
+    @Test
     fun stringConstantsAreNotUnboxed() {
         val thrift = """
             namespace java string_consts


### PR DESCRIPTION
The default clause returns null so these methods should be marked as
nullable when Android annotations are enabled.