### PR TITLE
Replace compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.microsoft.thrifty:thrifty-runtime:1.0.0-RC2'
+  implementation 'com.microsoft.thrifty:thrifty-runtime:1.0.0-RC2'
 }
 ```
 


### PR DESCRIPTION
Most recent versions of gradle now use `compile` instead of `implementation`