### PR TITLE
Add @NonNull to struct builder's copy constructor

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -416,9 +416,14 @@ class ThriftyCodeGenerator {
                 .addAnnotation(TypeNames.OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
 
+        val structParameterBuilder = ParameterSpec.builder(structClassName, "struct")
+        if (emitAndroidAnnotations) {
+            structParameterBuilder.addAnnotation(AnnotationSpec.builder(TypeNames.NOT_NULL).build())
+        }
+
         val copyCtor = MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(structClassName, "struct")
+                .addParameter(structParameterBuilder.build())
 
         val defaultCtor = MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -565,6 +565,26 @@ class ThriftyCodeGeneratorTest {
         assertThat(javaFile.toString()).contains(expectedFieldJavadoc)
     }
 
+    @Test
+    fun structBuilderCopyCtor() {
+        val thrift = """
+            namespace java structs.copy
+
+            struct Foo {
+              1: required string bar
+            }
+        """
+
+        val schema = parse("structs_builder_ctor.thrift", thrift)
+        val gen = ThriftyCodeGenerator(schema).emitAndroidAnnotations(true)
+        val javaFiles = gen.generateTypes()
+        val file = javaFiles[0]
+
+        val java = file.toString()
+
+        assertThat(java).contains("public Builder(@NonNull Foo struct)")
+    }
+
     private fun compile(filename: String, text: String): List<JavaFile> {
         val schema = parse(filename, text)
         val gen = ThriftyCodeGenerator(schema).emitFileComment(false)


### PR DESCRIPTION
The builder's copy constructor receives a `struct` value that can't be
null. Add `@NonNull` when Android annotations are enabled.

See #244 