### PR TITLE
Update Kotlin to 1.2.71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     version VERSION
 
     project.ext {
-        kotlin_version = '1.2.60'
+        kotlin_version = '1.2.71'
 
         libraries = [
                 clikt: [


### PR DESCRIPTION
Updating kotlin for better performance and fixes!

See the official [blogpost](https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/)