### PR TITLE
Update to Kotlin 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     version VERSION
 
     project.ext {
-        kotlin_version = '1.2.71'
+        kotlin_version = '1.3.0'
 
         libraries = [
                 clikt: [
@@ -85,7 +85,7 @@ buildscript {
 
     dependencies {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.17'
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
     }

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -131,10 +131,3 @@ compileTestJava {
 tasks['javadoc'].configure {
     exclude '**/generated-src/**'
 }
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
-}
-

--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
@@ -41,9 +41,9 @@ import com.microsoft.thrifty.transport.SocketTransport
 import com.microsoft.thrifty.transport.Transport
 import io.kotlintest.fail
 import io.kotlintest.shouldBe
-import kotlinx.coroutines.experimental.async
-import kotlinx.coroutines.experimental.awaitAll
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import okio.ByteString
 import org.junit.After
 import org.junit.Before

--- a/thrifty-kotlin-codegen/build.gradle
+++ b/thrifty-kotlin-codegen/build.gradle
@@ -37,9 +37,3 @@ dependencies {
 
     testImplementation 'com.google.testing.compile:compile-testing:0.9'
 }
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
-}

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -340,11 +340,11 @@ class KotlinCodeGeneratorTest {
             |    override suspend fun doSomething(foo: Int): Int = suspendCoroutine { cont ->
             |        this.enqueue(DoSomethingCall(foo, object : ServiceMethodCallback<Int> {
             |            override fun onSuccess(result: Int) {
-            |                cont.resume(result)
+            |                cont.resumeWith(Result.success(result))
             |            }
             |
             |            override fun onError(error: Throwable) {
-            |                cont.resumeWithException(error)
+            |                cont.resumeWith(Result.failure(error))
             |            }
             |        }))
             |    }

--- a/thrifty-runtime-ktx/build.gradle
+++ b/thrifty-runtime-ktx/build.gradle
@@ -25,11 +25,5 @@ apply plugin: 'kotlin'
 dependencies {
     api project(':thrifty-runtime')
     api libraries.kotlin
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0'
-}
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 }


### PR DESCRIPTION
Also updates our coroutine-based clients to use the newly non-experimental coroutine APIs, and removes the newly-useless experimental compiler argument.