### PR TITLE
Bump shadow plugin to remove Gradle deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.17'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
     }
 }
 


### PR DESCRIPTION
Version 2.x of the shadow plugin had an initialization bug causing warnings about use of deprecated Gradle features; the workaround was to specify `mainClassName` _prior_ to applying the plugin.  Happily, the 4.x release of the plugin fixes the bug.