### PR TITLE
Publish shadow jar for thrifty-compiler

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -120,8 +120,13 @@ afterEvaluate { project ->
     }
 
     artifacts {
-        archives jar
         archives javadocJar
         archives sourcesJar
+
+        if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
+            archives shadowJar
+        } else {
+            archives jar
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
Fixes #267 

This results in the the shadowed compiler jar being published with the classifier `all`.  I'm not yet sure whether (or how) we should distribute this jar beyond Maven Central; MC is great for build-time deps, but inconvenient for downloading command-line binaries.  No documentation changes for now.

This will take effect in the next non-snapshot release.