### PR TITLE
Use standard VM Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
   - oraclejdk8
   - openjdk10
 
-sudo: false
 install: echo './gradlew check will install dependencies'
 
 script:


### PR DESCRIPTION
Per https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures, the Travis container infrastructure is deprecated and will soon be disabled.  `sudo: false` opted us into it, so removing that line will put our builds back on the still-good VM infrastructure.