### PR TITLE
Strip trailing spaces in rendering and ignore in equality checking

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/SchemaFunctionalEquality.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/SchemaFunctionalEquality.kt
@@ -32,7 +32,7 @@ package com.microsoft.thrifty.schema
  * For comparing docs, we remove stars as things get weird in the parser.
  */
 private fun String.cleanedDoc(): String {
-    return trim().replace("*", "")
+    return trim().replace("*", "").split("\n").joinToString("\n") { it.trimEnd() }
 }
 
 /**

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/render/SchemaRendering.kt
@@ -460,7 +460,8 @@ private fun <A : Appendable> UserElement.renderJavadocTo(buffer: A, indent: Stri
                     prefix = "$indent/**$NEWLINE",
                     postfix = "$NEWLINE$indent */$NEWLINE"
                 ) {
-                    "$indent * $it"
+                    val line = if (it.isBlank()) "" else " ${it.trimEnd()}"
+                    "$indent *$line"
                 }
             }
         }


### PR DESCRIPTION
Saves a few bytes. Specifically would happen on cases where docs might have trailing spaces and avoids doing unnecessary trailing spaces in blank lines between docs