### PR TITLE
Expose read functionality from Adapter through Struct interface

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -222,7 +222,7 @@ class ThriftyCodeGenerator {
 
         val structBuilder = TypeSpec.classBuilder(type.name)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addSuperinterface(Struct::class.java)
+                .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Struct::class.java), structTypeName))
 
         if (type.hasJavadoc) {
             structBuilder.addJavadoc("\$L", type.documentation)
@@ -331,6 +331,7 @@ class ThriftyCodeGenerator {
         structBuilder.addMethod(buildHashCodeFor(type))
         structBuilder.addMethod(buildToStringFor(type))
         structBuilder.addMethod(buildWrite())
+        structBuilder.addMethod(buildRead(structTypeName))
 
         return structBuilder.build()
     }
@@ -657,6 +658,17 @@ class ThriftyCodeGenerator {
                 .addParameter(TypeNames.PROTOCOL, "protocol")
                 .addStatement("ADAPTER.write(protocol, this)")
                 .addException(TypeNames.IO_EXCEPTION)
+                .build()
+    }
+
+    private fun buildRead(structTypeName: ClassName): MethodSpec {
+        return MethodSpec.methodBuilder("read")
+                .addAnnotation(TypeNames.OVERRIDE)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(TypeNames.PROTOCOL, "protocol")
+                .addStatement("return ADAPTER.read(protocol)")
+                .addException(TypeNames.IO_EXCEPTION)
+                .returns(structTypeName)
                 .build()
     }
 

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -505,7 +505,7 @@ class ThriftyCodeGeneratorTest {
             /**
              * ${"$"}A ${"$"}B ${"$"}C ${"$"}D ${"$"}E
              */
-            public final class Foo implements Struct {
+            public final class Foo implements Struct<Foo> {
         """.trimRawString()
 
         val expectedFieldJavadoc = """

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -485,11 +485,20 @@ class KotlinCodeGenerator(
 
         if (shouldImplementStruct) {
             typeBuilder
-                    .addSuperinterface(Struct::class)
+                    .addSuperinterface(Struct::class.asTypeName().parameterizedBy(structClassName))
+            typeBuilder
                     .addFunction(FunSpec.builder("write")
                             .addModifiers(KModifier.OVERRIDE)
                             .addParameter("protocol", Protocol::class)
                             .addStatement("%L.write(protocol, this)", nameAllocator.get(Tags.ADAPTER))
+                            .build())
+
+            typeBuilder
+                    .addFunction(FunSpec.builder("read")
+                            .addModifiers(KModifier.OVERRIDE)
+                            .addParameter("protocol", Protocol::class)
+                            .addStatement("return %L.read(protocol)", nameAllocator.get(Tags.ADAPTER))
+                            .returns(structClassName)
                             .build())
         }
 

--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/Struct.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/Struct.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * An interface that Thrift struct objects should implement.
  */
-public interface Struct {
+public interface Struct<T> {
 
   /**
    * Writes this {@link Struct} instance to the given {@code protocol}.
@@ -36,4 +36,12 @@ public interface Struct {
    * @throws IOException if writing fails
    */
   void write(Protocol protocol) throws IOException;
+
+  /**
+   * Reads a new instance of {@link T} from the given {@code protocol}.
+   *
+   * @return an instance of {@link T} populated with the data just read.
+   * @throws IOException if reading fails, or if the struct is malformed
+   */
+   T read(Protocol protocol) throws IOException;
 }

--- a/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/Xtruct.java
+++ b/thrifty-runtime/src/test/java/com/microsoft/thrifty/protocol/Xtruct.java
@@ -29,7 +29,7 @@ import com.microsoft.thrifty.util.ProtocolUtil;
 
 import java.io.IOException;
 
-public final class Xtruct implements Struct {
+public final class Xtruct implements Struct<Xtruct> {
     public static final Adapter<Xtruct, Builder> ADAPTER = new XtructAdapter();
 
     @ThriftField(
@@ -112,6 +112,11 @@ public final class Xtruct implements Struct {
     @Override
     public void write(Protocol protocol) throws IOException {
         ADAPTER.write(protocol, this);
+    }
+
+    @Override
+    public Xtruct read(Protocol protocol) throws IOException {
+        return ADAPTER.read(protocol);
     }
 
     public static final class Builder implements StructBuilder<Xtruct> {


### PR DESCRIPTION
I've made this pull request as it is a small change and might be a good change. Code generation was fixed for both languages (Java and Kotlin) as well.

Similarly as `Adapter#write()` was exposed, I'm exposing it `Adapter#read()` as well.

This is a small change and not necessarily a valid case. 

Looking forward to your feedback.

Thank you!