### PR TITLE
Correct documentation for EnumType member lookup methods

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumType.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/EnumType.kt
@@ -41,14 +41,18 @@ class EnumType : UserType {
     }
 
     /**
-     * Find the [member][EnumMember] with the given [name], or null.
+     * Find the [member][EnumMember] with the given [name].
+     *
+     * @throws NoSuchElementException
      */
     fun findMemberByName(name: String): EnumMember {
         return members.first { it.name == name }
     }
 
     /**
-     * Find the [member][EnumMember] with the given [id], or null.
+     * Find the [member][EnumMember] with the given [id].
+     *
+     * @throws NoSuchElementException
      */
     fun findMemberById(id: Int): EnumMember {
         return members.first { it.value == id }


### PR DESCRIPTION
These have always been documented (incorrectly) to return null if no matching member is found.  They've always actually thrown NoSuchElementExceptions.  This commit changes the documentation to reflect that.

Fixes #283