### PR TITLE
Implement custom toString for kotlin unions

### DIFF
--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -539,6 +539,11 @@ class KotlinCodeGenerator(
                     .superclass(structClassName)
                     .addProperty(propertySpec.build())
                     .primaryConstructor(propConstructor.build())
+                    .addFunction(FunSpec.builder("toString")
+                            .addModifiers(KModifier.OVERRIDE)
+                            .returns(String::class)
+                            .addCode("return \"${struct.name}($name=\$value)\"")
+                            .build())
                     .build()
             typeBuilder.addType(dataProp)
         }

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -388,13 +388,17 @@ class KotlinCodeGeneratorTest {
 
         file.single().toString() should contain("""
             |
-            |    data class Foo(var value: Int?) : Union()
+            |    data class Foo(var value: Int?) : Union() {
+            |        override fun toString(): String = "Union(Foo=${'$'}value)"}
             |
-            |    data class Bar(var value: Long?) : Union()
+            |    data class Bar(var value: Long?) : Union() {
+            |        override fun toString(): String = "Union(Bar=${'$'}value)"}
             |
-            |    data class Baz(var value: String?) : Union()
+            |    data class Baz(var value: String?) : Union() {
+            |        override fun toString(): String = "Union(Baz=${'$'}value)"}
             |
-            |    data class NotFoo(var value: Int?) : Union()
+            |    data class NotFoo(var value: Int?) : Union() {
+            |        override fun toString(): String = "Union(NotFoo=${'$'}value)"}
             |
         """.trimMargin())
     }
@@ -796,7 +800,8 @@ class KotlinCodeGeneratorTest {
             |        ADAPTER.write(protocol, this)
             |    }
             |
-            |    data class Struct(var value: Bonk?) : UnionStruct()
+            |    data class Struct(var value: Bonk?) : UnionStruct() {
+            |        override fun toString(): String = "UnionStruct(Struct=${'$'}value)"}
             |
             |    class Builder : StructBuilder<UnionStruct> {
             |        private var Struct: Bonk?


### PR DESCRIPTION
The generated braces for nested sealed types are funky; seems like a kotlinpoet issue.  The code works, and does what we want, so :shipit: 

Fixes #287