### PR TITLE
Specify that a successful parse consumes all input

### DIFF
--- a/thrifty-integration-tests/ClientThriftTest.thrift
+++ b/thrifty-integration-tests/ClientThriftTest.thrift
@@ -465,7 +465,7 @@ union TestUnion {
   4: Bonk aBonk;
 }
 
-union EmptyUnion {};
+union EmptyUnion {}
 
 struct HasEmptyUnion {
   1: EmptyUnion theEmptyUnion;

--- a/thrifty-schema/src/main/antlr/com/microsoft/thrifty/schema/antlr/AntlrThrift.g4
+++ b/thrifty-schema/src/main/antlr/com/microsoft/thrifty/schema/antlr/AntlrThrift.g4
@@ -20,7 +20,7 @@
  */
 grammar AntlrThrift;
 
-document: header* definition*;
+document: header* definition* EOF;
 
 header
     : include

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
@@ -24,7 +24,11 @@ import com.microsoft.thrifty.schema.ErrorReporter
 import com.microsoft.thrifty.schema.Location
 import com.microsoft.thrifty.schema.NamespaceScope
 import com.microsoft.thrifty.schema.Requiredness
+import io.kotlintest.matchers.startWith
+import io.kotlintest.matchers.string.shouldContain
+import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrowExactly
 import okio.Okio
 
 import org.junit.After
@@ -1314,6 +1318,15 @@ class ThriftParserTest {
         )
 
         assertThat(file, equalTo(expected))
+    }
+
+    @Test
+    fun `top-level semicolons are a syntax error`() {
+        val thrift = "struct Empty {};"
+
+        val ex = shouldThrowExactly<IllegalStateException> { parse(thrift) }
+        ex.message should startWith("Syntax error")
+        // ex.message.shouldContain("';'") // reenable when we have improved syntax error reporting
     }
 
     companion object {


### PR DESCRIPTION
Prior to this commit, our generated antlr parser would happily stop midway through a file if it discovered a token it couldn't handle, such as a semicolon at the top level.  This was treated as a successful parse, leading to surprising cases of missing generated structs.

Fixed here by adding `EOF` to the end of our top-level `document` definition, which is the antlr way of saying "consume all input or else it is an error".

Fixes #297