### PR TITLE
Redirect ANTLR error messages to ErrorReporter

### DIFF
--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ParserErrorListener.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ParserErrorListener.kt
@@ -1,0 +1,28 @@
+package com.microsoft.thrifty.schema.parser
+
+import com.microsoft.thrifty.schema.ErrorReporter
+import com.microsoft.thrifty.schema.Location
+import org.antlr.v4.runtime.ANTLRErrorListener
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+
+/**
+ * Adapts [ErrorReporter] to the [ANTLRErrorListener] interface.
+ */
+internal class ParserErrorListener(
+        private val location: Location,
+        private val reporter: ErrorReporter
+) : BaseErrorListener() {
+    override fun syntaxError(
+            recognizer: Recognizer<*, *>?,
+            offendingSymbol: Any?,
+            line: Int,
+            charPositionInLine: Int,
+            msg: String,
+            e: RecognitionException?) {
+        // Antlr char positions are zero-based, location is not.
+        val loc = location.at(line, charPositionInLine + 1)
+        reporter.error(loc, msg)
+    }
+}

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftListener.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftListener.kt
@@ -409,10 +409,6 @@ internal class ThriftListener(
         return functions
     }
 
-    override fun visitErrorNode(node: ErrorNode) {
-        errorReporter.error(locationOf(node), node.text)
-    }
-
     // region Utilities
 
     private fun annotationsFromAntlr(ctx: AntlrThriftParser.AnnotationListContext?): AnnotationElement? {

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftParser.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftParser.kt
@@ -24,7 +24,11 @@ import com.microsoft.thrifty.schema.ErrorReporter
 import com.microsoft.thrifty.schema.Location
 import com.microsoft.thrifty.schema.antlr.AntlrThriftLexer
 import com.microsoft.thrifty.schema.antlr.AntlrThriftParser
-import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.ANTLRErrorListener
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.ConsoleErrorListener
+import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 import java.util.Locale
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftParser.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/parser/ThriftParser.kt
@@ -24,8 +24,7 @@ import com.microsoft.thrifty.schema.ErrorReporter
 import com.microsoft.thrifty.schema.Location
 import com.microsoft.thrifty.schema.antlr.AntlrThriftLexer
 import com.microsoft.thrifty.schema.antlr.AntlrThriftParser
-import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 import java.util.Locale
 
@@ -45,10 +44,11 @@ object ThriftParser {
      * @return a [ThriftFileElement] containing all Thrift elements in the input text.
      */
     fun parse(location: Location, text: String, reporter: ErrorReporter = ErrorReporter()): ThriftFileElement {
+        val errorListener = ParserErrorListener(location, reporter)
         val charStream = CharStreams.fromString(text, location.path)
-        val lexer = AntlrThriftLexer(charStream)
+        val lexer = AntlrThriftLexer(charStream).withErrorReporting(errorListener)
         val tokenStream = CommonTokenStream(lexer)
-        val antlrParser = AntlrThriftParser(tokenStream)
+        val antlrParser = AntlrThriftParser(tokenStream).withErrorReporting(errorListener)
         val documentParseTree = antlrParser.document()
 
         val thriftListener = ThriftListener(tokenStream, reporter, location)
@@ -62,5 +62,11 @@ object ThriftParser {
         }
 
         return thriftListener.buildFileElement()
+    }
+
+    private fun <T : Recognizer<*, *>> T.withErrorReporting(errorListener: ANTLRErrorListener): T {
+        removeErrorListener(ConsoleErrorListener.INSTANCE)
+        addErrorListener(errorListener)
+        return this
     }
 }

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
@@ -1326,7 +1326,7 @@ class ThriftParserTest {
 
         val ex = shouldThrowExactly<IllegalStateException> { parse(thrift) }
         ex.message should startWith("Syntax error")
-        // ex.message.shouldContain("';'") // reenable when we have improved syntax error reporting
+        ex.message.shouldContain("extraneous input ';'") // reenable when we have improved syntax error reporting
     }
 
     companion object {


### PR DESCRIPTION
Instead of using error nodes in `ThriftListener`, we can get better (and prefabricated) error messages directly from ANTLR using their ANTLRErrorListener interface.  As a side effect, we can also prevent antlr from spamming stderr!

Fixes #298