### PR TITLE
Add support for AndroidX nullability annotations

### DIFF
--- a/thrifty-compiler/README.md
+++ b/thrifty-compiler/README.md
@@ -20,6 +20,7 @@ Option | Description
 `--path=[dir]` | Optional.  Adds a directory to a search path, used for locating included thrift files.
 `--lang=[java,kotlin]` | Optional, defaults to java.  Specifies whether to generate Java or Kotlin code.
 `--name-style=[default,java]` | Optional.  Specifies how Thrift field names should be represented in generated code.  `default` leaves names unchanged, while `java` converts them to `camelCase`.
+`--use-android-annotations` | Optional, deprecated.  Equivalent to `--nullability-annotation-type=android-support`.
 `--nullability-annotation-type=[none,android-support,androidx]` | Optional, defaults to `none`.  Specifies whether or not Android nullability annotations will be added for generated fields (`@NonNull` and `@Nullable`) and, if so, which types - those in `android.support.annotation` or `androidx.annotation`.
 `--parcelable` | Optional.  Structs, unions, and exceptions will have implementations of Parcelable generated.
 `--omit-file-comments` | Optional.  When set, don't add file comments to generated files.

--- a/thrifty-compiler/README.md
+++ b/thrifty-compiler/README.md
@@ -20,7 +20,7 @@ Option | Description
 `--path=[dir]` | Optional.  Adds a directory to a search path, used for locating included thrift files.
 `--lang=[java,kotlin]` | Optional, defaults to java.  Specifies whether to generate Java or Kotlin code.
 `--name-style=[default,java]` | Optional.  Specifies how Thrift field names should be represented in generated code.  `default` leaves names unchanged, while `java` converts them to `camelCase`.
-`--use-android-annotations` | Optional.  When given, Android Support Annotations will be added for generated fields (`@NonNull` and `@Nullable`).
+`--nullability-annotation-type=[none,android-support,androidx]` | Optional, defaults to `none`.  Specifies whether or not Android nullability annotations will be added for generated fields (`@NonNull` and `@Nullable`) and, if so, which types - those in `android.support.annotation` or `androidx.annotation`.
 `--parcelable` | Optional.  Structs, unions, and exceptions will have implementations of Parcelable generated.
 `--omit-file-comments` | Optional.  When set, don't add file comments to generated files.
 `--omit-generated-annotations` | Optional.  When set, don't add @Generated annotations to generated types.

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -29,6 +29,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.transformAll
 import com.github.ajalt.clikt.parameters.options.validate
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.path
@@ -201,13 +202,13 @@ class ThriftyCompiler {
                         "none" to NullabilityAnnotationType.NONE,
                         "android-support" to NullabilityAnnotationType.ANDROID_SUPPORT,
                         "androidx" to NullabilityAnnotationType.ANDROIDX)
-                .default(
-                    if (emitNullabilityAnnotations) {
+                .transformAll {
+                    it.lastOrNull() ?: if (emitNullabilityAnnotations) {
                         NullabilityAnnotationType.ANDROID_SUPPORT
                     } else {
                         NullabilityAnnotationType.NONE
                     }
-                )
+                }
 
         val emitParcelable: Boolean by option("--parcelable",
                     help = "When set, generates Parcelable implementations for structs")

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -98,13 +98,13 @@ import java.util.ArrayList
  * `--use-android-annotations` (deprecated) is optional.  When specified, generated Java classes
  * will have `@android.support.annotation.Nullable` or `@android.support.annotation.NotNull`
  * annotations, as appropriate.  Has no effect on Kotlin code.  Note: This option is superseded by
- * `--nullability-annotation-type`. Setting this is equivalent to
+ * `--nullability-annotation-type`.  Setting this is equivalent to
  * `--nullability-annotation-type=android-support`.
  *
  * `--nullability-annotation-type=[none|android-support|androidx]` is optional, defaulting to
  * `none`.  When specified as something other than `none`, generated Java classes will have
  * `@Nullable` or `@NotNull` annotations, as appropriate.  Since AndroidX was introduced, these
- * annotations were repackaged from `android.support.annotation` to `androidx.annotation`. Use
+ * annotations were repackaged from `android.support.annotation` to `androidx.annotation`.  Use
  * the `android-support` option for projects that are using the Android Support Library and have
  * not migrated to AndroidX.  Use the `androidx` option for projects that have migrated to AndroidX.
  * Has no effect on Kotlin code.

--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/TypeNames.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/TypeNames.kt
@@ -103,8 +103,10 @@ internal object TypeNames {
     val OBFUSCATED = classNameOf<Obfuscated>()
     val THRIFT_FIELD = classNameOf<ThriftField>()
 
-    val NOT_NULL = ClassName.get("android.support.annotation", "NonNull")
-    val NULLABLE = ClassName.get("android.support.annotation", "Nullable")
+    val ANDROID_SUPPORT_NOT_NULL = ClassName.get("android.support.annotation", "NonNull")
+    val ANDROID_SUPPORT_NULLABLE = ClassName.get("android.support.annotation", "Nullable")
+    val ANDROIDX_NOT_NULL = ClassName.get("androidx.annotation", "NonNull")
+    val ANDROIDX_NULLABLE = ClassName.get("androidx.annotation", "Nullable")
 
     val SERVICE_CALLBACK = classNameOf<ServiceMethodCallback<*>>()
     val SERVICE_CLIENT_BASE = classNameOf<AsyncClientBase>()
@@ -141,6 +143,21 @@ internal object TypeNames {
             else -> throw NoSuchElementException("not a TType member: $code")
         }
     }
+}
+
+enum class NullabilityAnnotationType(
+    internal val notNullClassName: ClassName?,
+    internal val nullableClassName: ClassName?
+) {
+    NONE(null, null),
+    ANDROID_SUPPORT(
+            notNullClassName = TypeNames.ANDROID_SUPPORT_NOT_NULL,
+            nullableClassName = TypeNames.ANDROID_SUPPORT_NULLABLE
+    ),
+    ANDROIDX(
+            notNullClassName = TypeNames.ANDROIDX_NOT_NULL,
+            nullableClassName = TypeNames.ANDROIDX_NULLABLE
+    )
 }
 
 internal inline fun <reified T> classNameOf(): ClassName = ClassName.get(T::class.java)

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -236,9 +236,9 @@ class ThriftyCodeGeneratorTest {
         assertThat(java).contains("@Nullable\n  public static BuildStatus findByValue")
     }
 
-  @Test
-  fun noNullabilityAnnotations() {
-    val thrift = """
+    @Test
+    fun noNullabilityAnnotations() {
+        val thrift = """
             namespace java no_nullability
 
             struct foo {
@@ -246,17 +246,17 @@ class ThriftyCodeGeneratorTest {
             }
         """
 
-    val schema = parse("no_nullability.thrift", thrift)
-    val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.NONE)
-    val javaFiles = gen.generateTypes()
-    val file = javaFiles[0]
+        val schema = parse("no_nullability.thrift", thrift)
+        val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.NONE)
+        val javaFiles = gen.generateTypes()
+        val file = javaFiles[0]
 
-    val java = file.toString()
+        val java = file.toString()
 
-    assertThat(java).doesNotContain("@Nullable")
-    assertThat(java).doesNotContain("import android.support.annotation")
-    assertThat(java).doesNotContain("import androidx.annotation")
-  }
+        assertThat(java).doesNotContain("@Nullable")
+        assertThat(java).doesNotContain("import android.support.annotation")
+        assertThat(java).doesNotContain("import androidx.annotation")
+    }
 
     @Test
     fun nullableAndroidSupportAnnotations() {
@@ -282,7 +282,7 @@ class ThriftyCodeGeneratorTest {
 
     @Test
     fun nullableAndroidXAnnotations() {
-      val thrift = """
+        val thrift = """
             namespace java nullable_androidx
 
             struct foo {

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -227,13 +227,79 @@ class ThriftyCodeGeneratorTest {
         """
 
         val schema = parse("enum_nullable.thrift", thrift)
-        val gen = ThriftyCodeGenerator(schema).emitAndroidAnnotations(true)
+        val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.ANDROID_SUPPORT)
         val javaFiles = gen.generateTypes()
         val file = javaFiles[0]
 
         val java = file.toString()
 
         assertThat(java).contains("@Nullable\n  public static BuildStatus findByValue")
+    }
+
+  @Test
+  fun noNullabilityAnnotations() {
+    val thrift = """
+            namespace java no_nullability
+
+            struct foo {
+                1: string bar
+            }
+        """
+
+    val schema = parse("no_nullability.thrift", thrift)
+    val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.NONE)
+    val javaFiles = gen.generateTypes()
+    val file = javaFiles[0]
+
+    val java = file.toString()
+
+    assertThat(java).doesNotContain("@Nullable")
+    assertThat(java).doesNotContain("import android.support.annotation")
+    assertThat(java).doesNotContain("import androidx.annotation")
+  }
+
+    @Test
+    fun nullableAndroidSupportAnnotations() {
+        val thrift = """
+            namespace java nullable_android_support
+
+            struct foo {
+                1: string bar
+            }
+        """
+
+        val schema = parse("nullable_android_support.thrift", thrift)
+        val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.ANDROID_SUPPORT)
+        val javaFiles = gen.generateTypes()
+        val file = javaFiles[0]
+
+        val java = file.toString()
+
+        assertThat(java).contains("@Nullable\n  public final String bar")
+        assertThat(java).contains("import android.support.annotation")
+        assertThat(java).doesNotContain("import androidx.annotation")
+    }
+
+    @Test
+    fun nullableAndroidXAnnotations() {
+      val thrift = """
+            namespace java nullable_androidx
+
+            struct foo {
+                1: string bar
+            }
+        """
+
+        val schema = parse("nullable_androidx.thrift", thrift)
+        val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.ANDROIDX)
+        val javaFiles = gen.generateTypes()
+        val file = javaFiles[0]
+
+        val java = file.toString()
+
+        assertThat(java).contains("@Nullable\n  public final String bar")
+        assertThat(java).contains("import androidx.annotation")
+        assertThat(java).doesNotContain("import android.support.annotation")
     }
 
     @Test
@@ -536,7 +602,7 @@ class ThriftyCodeGeneratorTest {
         """
 
         val schema = parse("structs_builder_ctor.thrift", thrift)
-        val gen = ThriftyCodeGenerator(schema).emitAndroidAnnotations(true)
+        val gen = ThriftyCodeGenerator(schema).nullabilityAnnotationType(NullabilityAnnotationType.ANDROID_SUPPORT)
         val javaFiles = gen.generateTypes()
         val file = javaFiles[0]
 


### PR DESCRIPTION
While many projects that have migrated to AndroidX are also on board with Kotlin, there are exceptions. It's even a reasonable use case to stick with Java for these generated files, since they'll compile marginally faster and the implementations for `equals()`, `toString()` and such aren't meant to be manually modified anyway.

This adds an option to use AndroidX's annotations. It unblocks aforementioned projects from using nullability annotations with this compiler (or having to modify the generated source to use the AndroidX imports). 