### PR TITLE
Print LoadFailedException cause on load failure

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -271,6 +271,9 @@ class ThriftyCompiler {
             try {
                 schema = loader.load()
             } catch (e: LoadFailedException) {
+                if (!e.errorReporter.hasError && e.cause != null) {
+                    println(e.cause)
+                }
                 for (report in e.errorReporter.formattedReports()) {
                     println(report)
                 }


### PR DESCRIPTION
LoadFailedException wraps a list of error reports. In the load path,
these reports are primarily added by the parser, but we also construct
LoadFailedException objects to wrap FileNotFoundException instances.

The compiler previously only printed the formatted reports. Other
wrapped exception causes were effectively swallowed which lead to
ambiguous compilation failures when an included .thrift file couldn't be
loaded, for example.

This change prints the underlying cause when the LoadFailedException
doesn't have any error reports. This feels like a good compromise that
addresses the root problem of certain exception cases being swallowed.

Alternatively, we could avoid wrapping FileNotFoundException and let is
bubble up on its own, but that would be a change from the currently
documented "contract" where we except all load errors to be represented
by LoadFailedException.