### PR TITLE
Introduce an --omit-service-clients option

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -60,6 +60,7 @@ import java.util.ArrayList
  * [--parcelable]
  * [--use-android-annotations]
  * [--nullability-annotation-type=[none|android-support|androidx]]
+ * [--omit-service-clients]
  * [--omit-file-comments]
  * [--omit-generated-annotations]
  * [--generated-annotation-type=[jdk8|jdk9|native]]
@@ -109,6 +110,8 @@ import java.util.ArrayList
  * the `android-support` option for projects that are using the Android Support Library and have
  * not migrated to AndroidX.  Use the `androidx` option for projects that have migrated to AndroidX.
  * Has no effect on Kotlin code.
+ *
+ * `--omit-service-clients` is optional.  When specified, no service clients are generated.
  *
  * `--omit-file-comments` is optional.  When specified, no file-header comment is generated.
  * The default behavior is to prefix generated files with a comment indicating that they
@@ -212,6 +215,10 @@ class ThriftyCompiler {
 
         val emitParcelable: Boolean by option("--parcelable",
                     help = "When set, generates Parcelable implementations for structs")
+                .flag(default = false)
+
+        val omitServiceClients: Boolean by option("--omit-service-clients",
+                    help = "When set, don't generate service clients")
                 .flag(default = false)
 
         val omitFileComments: Boolean by option("--omit-file-comments",
@@ -336,6 +343,10 @@ class ThriftyCompiler {
 
             if (emitParcelable) {
                 gen.parcelize()
+            }
+
+            if (omitServiceClients) {
+                gen.omitServiceClients()
             }
 
             if (kotlinFilePerType) {

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -350,6 +350,20 @@ class KotlinCodeGeneratorTest {
         """.trimMargin())
     }
 
+    @Test
+    fun `omit service clients`() {
+        val thrift = """
+            |namespace kt test.omit_service_clients
+            |
+            |service Svc {
+            |  i32 doSomething(1: i32 foo);
+            |}
+        """.trimMargin()
+
+        val file = generate(thrift) { omitServiceClients() }
+
+        file shouldBe emptyList()
+    }
 
     @Test
     fun `union generate sealed`() {


### PR DESCRIPTION
When specified, no service clients will be generated. We only support
service clients in the Kotlin generator, so this is implicitly a
Kotlin-only option, but it's not prefixed with `kt` because it could
apply to Java in the future.

This is useful for projects that only need Thrift-generated structures,
etc. and won't use Thrift service calls.