### PR TITLE
Introduce a --kt-emit-jvmname option

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -238,6 +238,10 @@ class ThriftyCompiler {
                         "native" to nativeGeneratedAnnotation)
                 .default("javax.annotation.Generated")
 
+        val kotlinEmitJvmName: Boolean by option("--kt-emit-jvmname",
+                    help = "When set, emit @JvmName annotations")
+                .flag(default = false)
+
         val kotlinFilePerType: Boolean by option(
                     "--kt-file-per-type", help = "Generate one .kt file per type; default is one per namespace.")
                 .flag(default = false)
@@ -347,6 +351,10 @@ class ThriftyCompiler {
 
             if (omitServiceClients) {
                 gen.omitServiceClients()
+            }
+
+            if (kotlinEmitJvmName) {
+                gen.emitJvmName()
             }
 
             if (kotlinFilePerType) {

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -366,6 +366,62 @@ class KotlinCodeGeneratorTest {
     }
 
     @Test
+    fun `Emit @JvmName file-per-namespace annotations`() {
+        val thrift = """
+            |namespace kt test.consts
+            |
+            |const i32 FooNum = 42
+        """.trimMargin()
+
+        val text = generate(thrift) {
+                    emitJvmName()
+                    filePerNamespace()
+                }
+                .single()
+                .toString()
+
+        text shouldBe """
+            |@file:JvmName("ThriftTypes")
+            |
+            |package test.consts
+            |
+            |import kotlin.Int
+            |import kotlin.jvm.JvmName
+            |
+            |const val FooNum: Int = 42
+            |
+            """.trimMargin()
+    }
+
+    @Test
+    fun `Emit @JvmName file-per-type annotations`() {
+        val thrift = """
+            |namespace kt test.consts
+            |
+            |const i32 FooNum = 42
+        """.trimMargin()
+
+        val text = generate(thrift) {
+                    emitJvmName()
+                    filePerType()
+                }
+                .single()
+                .toString()
+
+        text shouldBe """
+            |@file:JvmName("Constants")
+            |
+            |package test.consts
+            |
+            |import kotlin.Int
+            |import kotlin.jvm.JvmName
+            |
+            |const val FooNum: Int = 42
+            |
+            """.trimMargin()
+    }
+
+    @Test
     fun `union generate sealed`() {
         val thrift = """
             |namespace kt test.coro


### PR DESCRIPTION
When specified, `@file:JvmName(name)` annotations will be added to all
of the generated files. This improves the usability of importing these
Kotlin-based classes into Java code modules (e.g. as `foo.Constants`
instead of `foo.ConstantsKt`).

This would ideally be the default behavior, but it's introduced as an
opt-in compiler option to avoid breaking backwards compatibility.