### PR TITLE
Bump clikt to from 1.4.0 to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
 
         libraries = [
                 clikt: [
-                        'com.github.ajalt:clikt:1.4.0'
+                        'com.github.ajalt:clikt:2.6.0'
                 ],
 
                 guava: [

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -172,12 +172,12 @@ class ThriftyCompiler {
         }
 
         val outputDirectory: Path by option("-o", "--out", help = "the output directory for generated files")
-                .path(fileOkay = false, folderOkay = true)
+                .path(canBeFile = false, canBeDir = true)
                 .required()
                 .validate { Files.isDirectory(it) || !Files.exists(it) }
 
         val searchPath: List<Path> by option("-p", "--path", help = "the search path for .thrift includes")
-                .path(exists = true, folderOkay = true, fileOkay = false)
+                .path(mustExist = true, canBeDir = true, canBeFile = false)
                 .multiple()
 
         val language: Language? by option(
@@ -253,7 +253,7 @@ class ThriftyCompiler {
                 .flag(default = false)
 
         val thriftFiles: List<Path> by argument(help = "All .thrift files to compile")
-                .path(exists = true, fileOkay = true, folderOkay = false, readable = true)
+                .path(mustExist = true, canBeFile = true, canBeDir = false, mustBeReadable = true)
                 .multiple()
 
         private val generatedAnnotationClassName: String? by lazy {


### PR DESCRIPTION
This removes the last source of kotlin 1.3.0 stdlib dependencies, clearing the way for a Gradle upgrade.