### PR TITLE
Bump shadow-jar to 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.17'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/thrifty-compiler/build.gradle
+++ b/thrifty-compiler/build.gradle
@@ -53,13 +53,9 @@ shadowJar {
     }
 }
 
-task compileTestCase(type: Exec) {
-    def jarTask = project.tasks['shadowJar'] as Jar
-
-    dependsOn jarTask
-
-    executable 'java'
-    args = ['-jar', jarTask.archivePath.absolutePath, "--name-style=java", "--out=$projectDir/build/generated-src/gen/java", "$projectDir/TestThrift.thrift"]
+tasks.register('compileTestCase', JavaExec) { t ->
+    t.classpath(shadowJar.archiveFile)
+    t.args = ["--name-style=java", "--out=$projectDir/build/generated-src/gen/java", "$projectDir/TestThrift.thrift"]
 }
 
 afterEvaluate {

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -53,37 +53,26 @@ shadowJar {
 
 mainClassName = 'com.microsoft.thrifty.compiler.ThriftyCompiler'
 
-task compileTestThrift(type: Exec) {
-    def jarTask = project.tasks['shadowJar'] as Jar
+def compileTestThrift = tasks.register("compileTestThrift", JavaExec) { t ->
+    t.inputs.file("$projectDir/ClientThriftTest.thrift")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty/java")
 
-    inputs.file("$projectDir/ClientThriftTest.thrift")
-    outputs.dir("$projectDir/build/generated-src/thrifty/java")
+    t.classpath shadowJar.archiveFile
 
-    dependsOn jarTask
-
-    executable 'java'
     args = [
-            '-jar',
-            jarTask.archivePath.absolutePath,
             "--out=$projectDir/build/generated-src/thrifty/java",
             "--generated-annotation-type=native",
             "$projectDir/ClientThriftTest.thrift"]
 }
 
 
-task kompileTestThrift(type: Exec) {
-    def jarTask = project.tasks['shadowJar'] as Jar
+def kompileTestThrift = tasks.register("kompileTestThrift", JavaExec) { t ->
+    t.inputs.file("$projectDir/ClientThriftTest.thrift")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
 
-    inputs.file("$projectDir/ClientThriftTest.thrift")
-    inputs.files(jarTask.outputs)
-    outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
+    t.classpath shadowJar.archiveFile
 
-    dependsOn jarTask
-
-    executable 'java'
     args = [
-            '-jar',
-            jarTask.archivePath.absolutePath,
             "--out=$projectDir/build/generated-src/thrifty/kotlin",
             "--lang=kotlin",
             "--map-type=java.util.LinkedHashMap",
@@ -94,19 +83,13 @@ task kompileTestThrift(type: Exec) {
     ]
 }
 
-task kompileCoroutineTestThrift(type: Exec) {
-    def jarTask = project.tasks['shadowJar'] as Jar
+def kompileCoroutineTestThrift = tasks.register("kompileCoroutineTestThrift", JavaExec) { t ->
+    t.inputs.file("$projectDir/CoroutineClientTest.thrift")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
 
-    inputs.file("$projectDir/CoroutineClientTest.thrift")
-    inputs.files(jarTask.outputs)
-    outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
+    t.classpath shadowJar.archiveFile
 
-    dependsOn jarTask
-
-    executable 'java'
     args = [
-            '-jar',
-            jarTask.archivePath.absolutePath,
             "--out=$projectDir/build/generated-src/thrifty/kotlin",
             "--lang=kotlin",
             "--generated-annotation-type=native",


### PR DESCRIPTION
Also, remove some deprecated uses of the shadowJar task's `archivePath` property, taking the opportunity to more lazily configure test tasks.

This is necessary because future Gradle releases will render our current version of shadow-jar inoperable.