### PR TITLE
Bump okio from 1.14.1 to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ allprojects {
                 ],
 
                 okio: [
-                        'com.squareup.okio:okio:1.14.1'
+                        'com.squareup.okio:okio:2.6.0'
                 ],
 
                 testing: [

--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
@@ -48,7 +48,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
-import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -174,7 +174,7 @@ class CoroutineConformanceTests(
     }
 
     @Test fun testBinary() = runBlocking {
-        val binary = ByteString.encodeUtf8("Peace on Earth and Thrift for all mankind")
+        val binary = "Peace on Earth and Thrift for all mankind".encodeUtf8()
 
         client.testBinary(binary) shouldBe binary
     }

--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
@@ -47,6 +47,7 @@ import io.kotest.matchers.beInstanceOf
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -190,7 +191,7 @@ class KotlinConformanceTest(
     }
 
     @Test fun testBinary() {
-        val binary = ByteString.encodeUtf8("Peace on Earth and Thrift for all mankind")
+        val binary = "Peace on Earth and Thrift for all mankind".encodeUtf8()
 
         val callback = AssertingCallback<ByteString>()
         client.testBinary(binary, callback)

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -28,7 +28,8 @@ import com.google.testing.compile.JavaSourcesSubjectFactory.javaSources
 import com.microsoft.thrifty.schema.Loader
 import com.microsoft.thrifty.schema.Schema
 import com.squareup.javapoet.JavaFile
-import okio.Okio
+import okio.buffer
+import okio.sink
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -651,7 +652,7 @@ class ThriftyCodeGeneratorTest {
 
         val trimmed = text.trimStart('\n').trimIndent()
 
-        Okio.buffer(Okio.sink(file)).use { sink ->
+        file.sink().buffer().use { sink ->
             sink.writeUtf8(trimmed)
             sink.flush()
         }

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Loader.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Loader.kt
@@ -24,7 +24,8 @@ import com.google.common.base.Preconditions
 import com.microsoft.thrifty.schema.parser.ThriftFileElement
 import com.microsoft.thrifty.schema.parser.ThriftParser
 import com.microsoft.thrifty.schema.render.filepath
-import okio.Okio
+import okio.buffer
+import okio.source
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.FileSystems
@@ -232,10 +233,10 @@ class Loader {
             return null
         }
 
-        Okio.source(file).use { source ->
+        file.source().use { source ->
             try {
                 val location = Location.get("$base", "$fileName")
-                val data = Okio.buffer(source).readUtf8()
+                val data = source.buffer().readUtf8()
                 return ThriftParser.parse(location, data, errorReporter)
             } catch (e: IOException) {
                 throw IOException("Failed to load $fileName from $base", e)

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/parser/ThriftParserTest.kt
@@ -29,7 +29,8 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.startWith
-import okio.Okio
+import okio.buffer
+import okio.source
 
 import org.junit.After
 import org.junit.Before
@@ -783,7 +784,7 @@ class ThriftParserTest {
     fun canParseOfficialTestCase() {
         val classLoader = javaClass.classLoader
         val stream = classLoader.getResourceAsStream("cases/TestThrift.thrift")
-        val thrift = Okio.buffer(Okio.source(stream!!)).readUtf8()
+        val thrift = stream!!.source().buffer().readUtf8()
         val location = Location.get("cases", "TestThrift.thrift")
 
         // Not crashing is good enough here.  We'll be more strict with this file in the loader test.


### PR DESCRIPTION
This one might be more controversial because at 2.0.0 okio switched from Java to Kotlin.  Therefore this upgrade will cause `thrifty-runtime` to carry a Kotlin dependency, which historically we've resisted.  We've resisted in an effort to keep the method-count imposed by thrifty to an absolute minimum.

Five+ years into thrifty's life, I feel like Kotlin is more or less unavoidable in Android, especially in the apps I know to use thrifty.  Having a kotlin dependency seems quite unlikely to impose a substantial increase in method count.  Method counts are also much less important than they once were.

The reasons to upgrade are a bit nebulous but still important:
- Avoiding bitrot.  As apps keep up-to-date, the chance that we rely on binary-incompatible APIs increases.
- Bugfixes in okio - they happen!
- Opens the door to Kotlin MPP thrifty

I'll leave this open for a while - if you have thoughts, please share them here!