### PR TITLE
Fix null check in reading enum values

### DIFF
--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -990,11 +990,11 @@ class KotlinCodeGenerator(
                             addStatement("%N = $name", localFieldName(field))
                         }
                     } else if (builderType != null) {
-                        beginControlFlow("$name.let")
+                        beginControlFlow("$name?.let")
                         addStatement("builder.$name(it)")
                         endControlFlow()
                     } else {
-                        beginControlFlow("$name.let")
+                        beginControlFlow("$name?.let")
                         addStatement("%N = it", localFieldName(field))
                         endControlFlow()
                     }

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -883,7 +883,7 @@ class KotlinCodeGeneratorTest {
               val field1 = protocol.readI32().let {
                 TestEnum.findByValue(it)
               }
-              field1.let {
+              field1?.let {
                 builder.field1(it)
               }
             } else {
@@ -926,7 +926,7 @@ class KotlinCodeGeneratorTest {
               val field1 = protocol.readI32().let {
                 TestEnum.findByValue(it)
               }
-              field1.let {
+              field1?.let {
                 _local_field1 = it
               }
             } else {


### PR DESCRIPTION
Bug was introduced in PR #357. `.let` does nothing. It should be `?.let`