### PR TITLE
Explicitly call fail() on a failed request when an exception occurs

### DIFF
--- a/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/AsyncClientBase.java
+++ b/thrifty-runtime/src/main/java/com/microsoft/thrifty/service/AsyncClientBase.java
@@ -203,6 +203,7 @@ public class AsyncClientBase extends ClientBase implements Closeable {
             try {
                 result = AsyncClientBase.this.invokeRequest(call);
             } catch (IOException | RuntimeException e) {
+                fail(call, e);
                 throw e;
             } catch (ServerException e) {
                 error = e.thriftException;


### PR DESCRIPTION
If an exception occurs when performing a client request (i.e. an
IOException or a RuntimeException) then the request never completes,
even with a fail.

This happens because these types of exceptions are handled differently
in `AsyncClientBase.invokeRequest()` than other types, and the
exception is re-thrown without `fail`-ing the request leaving
client code hung.

This patch fixes the problem #358.

Signed-off-by: Alexey Morozov <morozov@gmail.com>