### PR TITLE
Fix Maven publication

### DIFF
--- a/thrifty-compiler-plugins/gradle.properties
+++ b/thrifty-compiler-plugins/gradle.properties
@@ -1,2 +1,3 @@
 POM_NAME=thrifty-compiler-plugins
+POM_DESCRIPTION=An SPI definition for thrifty-compiler plugins
 POM_ARTIFACT_ID=thrifty-compiler-plugins

--- a/thrifty-compiler/gradle.properties
+++ b/thrifty-compiler/gradle.properties
@@ -1,2 +1,3 @@
 POM_NAME=thrifty-compiler
+POM_DESCRIPTION=A command-line utility to compile .thrift files into a Thrifty schema.
 POM_ARTIFACT_ID=thrifty-compiler

--- a/thrifty-gradle-plugin/build.gradle
+++ b/thrifty-gradle-plugin/build.gradle
@@ -21,6 +21,7 @@
 
 apply plugin: 'kotlin'
 apply plugin: 'java-gradle-plugin'
+apply plugin: 'com.vanniktech.maven.publish'
 
 gradlePlugin {
     plugins {

--- a/thrifty-gradle-plugin/gradle.properties
+++ b/thrifty-gradle-plugin/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=thrifty-gradle-plugin
+POM_DESCRIPTION=A Gradle plugin that compiles .thrift files into Thrifty sources.
+POM_ARTIFACT_ID=thrifty-gradle-plugin


### PR DESCRIPTION
We're missing POM descriptions for a few modules, and forgot to publish the new gradle module.