### PR TITLE
Add API to configure which specific thrift files get compiled

### DIFF
--- a/thrifty-gradle-plugin/README.md
+++ b/thrifty-gradle-plugin/README.md
@@ -17,9 +17,24 @@ thrifty {
     // By default, thrifty will use all thrift files in 'src/main/thrift'.
     // You can override this in the following ways:
 
-    // Specify one or more directories containing thrift tiles.
+    // Specify a directory containing thrift files.
     // Note that if you do, 'src/main/thrift' is ignored.
+    // By default, all .thrift files in this directory and its subdirectores
+    // will be compiled.
     sourceDir 'path/to/thrift/files', 'path/to/other/thrift/files'
+
+    // Specify several directories containing thrift files, as above.
+    // Note the plural name 'sourceDirs'.
+    sourceDirs 'path/to/thrift/files', 'path/to/other/thrift/files'
+
+    // Specify a directory containing thrift files along with glob patterns
+    // identifying the exact files to include or exclude.
+    sourceDir('path/to/thrift/files') {
+        // Include and exclude patterns as per:
+        // https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/util/PatternFilterable.html
+        include '**/*.thrift'
+        exclude '**/*.analytics.thrift'
+    }
 
     // Augment the thrift include path with one or more directories:
     includeDir 'path/to/include/dir', 'path/to/other/dir'

--- a/thrifty-gradle-plugin/src/main/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePlugin.kt
+++ b/thrifty-gradle-plugin/src/main/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePlugin.kt
@@ -104,7 +104,7 @@ class ThriftyGradlePlugin : Plugin<Project> {
                 require(it.exists()) { "Thrift include-path entry $it does not exist" }
                 require(it.isDirectory) { "Thrift include-path entry $it must be a directory, but is a file" }
 
-                val dep = project.dependencies.create(it)
+                val dep = project.dependencies.create(project.files(it))
                 pathConfiguration.dependencies.add(dep)
             }.map {
                 it.toPath()

--- a/thrifty-gradle-plugin/src/main/kotlin/com/microsoft/thrifty/gradle/ThriftyTask.kt
+++ b/thrifty-gradle-plugin/src/main/kotlin/com/microsoft/thrifty/gradle/ThriftyTask.kt
@@ -41,6 +41,7 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import java.io.IOException
 import java.nio.file.Path
 import javax.inject.Inject
 
@@ -72,6 +73,13 @@ open class ThriftyTask @Inject constructor(
         } catch (e: LoadFailedException) {
             reportThriftParseError(e)
             throw GradleException("Thrift compilation failed")
+        }
+
+        try {
+            outputDirectory.asFile.get().deleteRecursively()
+        } catch (e: IOException) {
+            // eh
+            logger.warn("Error clearing stale output", e)
         }
 
         when (val opt = options.get()) {

--- a/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
+++ b/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
@@ -72,6 +72,10 @@ class ThriftyGradlePluginTest {
         runner.buildFixture("kotlin_multiple_source_dirs") { build() }
     }
 
+    @Test fun `kotlin project with incude path`() {
+        runner.buildFixture("kotlin_project_with_include_path") { build() }
+    }
+
     private fun GradleRunner.buildFixture(fixtureName: String, buildAndAssert: GradleRunner.() -> BuildResult): BuildResult {
         val fixture = File(fixturesDir, fixtureName)
         val settings = File(fixture, "settings.gradle")

--- a/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
+++ b/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
@@ -64,6 +64,14 @@ class ThriftyGradlePluginTest {
         runner.buildFixture("kotlin_project_java_thrifts") { build() }
     }
 
+    @Test fun `kotlin project with filtered thrift inputs`() {
+        runner.buildFixture("kotlin_project_filtered_thrifts") { build() }
+    }
+
+    @Test fun `kotlin project with multiple thrift dirs`() {
+        runner.buildFixture("kotlin_multiple_source_dirs") { build() }
+    }
+
     private fun GradleRunner.buildFixture(fixtureName: String, buildAndAssert: GradleRunner.() -> BuildResult): BuildResult {
         val fixture = File(fixturesDir, fixtureName)
         val settings = File(fixture, "settings.gradle")

--- a/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
+++ b/thrifty-gradle-plugin/src/test/kotlin/com/microsoft/thrifty/gradle/ThriftyGradlePluginTest.kt
@@ -72,7 +72,7 @@ class ThriftyGradlePluginTest {
         runner.buildFixture("kotlin_multiple_source_dirs") { build() }
     }
 
-    @Test fun `kotlin project with incude path`() {
+    @Test fun `kotlin project with include path`() {
         runner.buildFixture("kotlin_project_with_include_path") { build() }
     }
 

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'com.microsoft.thrifty'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+thrifty {
+    kotlin {}
+
+    sourceDir "src/main/thrift-a"
+    sourceDir "src/main/thrift-b"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+    api "com.microsoft.thrifty:thrifty-runtime-ktx:2.0.1"
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
@@ -1,0 +1,9 @@
+package com.microsoft.thrifty.test
+
+fun newFooFetcher(): FooFetcher {
+    TODO("not implemented")
+}
+
+fun printBonk(bonk: Bonk) {
+    println(bonk.bonk)
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/thrift-a/microsoft/thrifty/sample.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/thrift-a/microsoft/thrifty/sample.thrift
@@ -1,0 +1,10 @@
+namespace jvm com.microsoft.thrifty.test;
+
+struct Foo {
+    1: optional string name;
+    2: optional i64 number;
+}
+
+service FooFetcher {
+    Foo fetchFoo();
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/thrift-b/microsoft/thrifty/bonk.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/src/main/thrift-b/microsoft/thrifty/bonk.thrift
@@ -1,0 +1,5 @@
+namespace jvm com.microsoft.thrifty.test;
+
+struct Bonk {
+  1: optional string bonk;
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'com.microsoft.thrifty'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+thrifty {
+    kotlin {}
+
+    sourceDir("src/main/thrift") {
+        include "**/sample.thrift"
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+    api "com.microsoft.thrifty:thrifty-runtime-ktx:2.0.1"
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
@@ -1,0 +1,5 @@
+package com.microsoft.thrifty.test
+
+fun newFooFetcher(): FooFetcher {
+    TODO("not implemented")
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/thrift/microsoft/thrifty/invalid.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/thrift/microsoft/thrifty/invalid.thrift
@@ -1,0 +1,7 @@
+namespace jvm com.microsoft.thrifty.test;
+
+struct Bar {
+    1: optional string name;
+    2: optional i64 number;
+    lol this is not thrift
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/thrift/microsoft/thrifty/sample.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/src/main/thrift/microsoft/thrifty/sample.thrift
@@ -1,0 +1,10 @@
+namespace jvm com.microsoft.thrifty.test;
+
+struct Foo {
+    1: optional string name;
+    2: optional i64 number;
+}
+
+service FooFetcher {
+    Foo fetchFoo();
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'com.microsoft.thrifty'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+thrifty {
+    includeDir 'common'
+    kotlin {}
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+    api "com.microsoft.thrifty:thrifty-runtime-ktx:2.0.1"
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/common/common.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/common/common.thrift
@@ -1,0 +1,6 @@
+namespace jvm com.microsoft.thrifty.test;
+
+struct Foo {
+    1: optional string name;
+    2: optional i64 number;
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/src/main/kotlin/com/microsoft/thrifty/test/Sample.kt
@@ -1,0 +1,5 @@
+package com.microsoft.thrifty.test
+
+fun printFoo(foo: Foo) {
+    println("$foo")
+}

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/src/main/thrift/sample.thrift
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/src/main/thrift/sample.thrift
@@ -1,0 +1,12 @@
+namespace jvm com.microsoft.thrifty.test;
+
+include "common.thrift";
+
+struct Foo {
+    1: optional string name;
+    2: optional i64 number;
+}
+
+service FooFetcher {
+    common.Foo fetchFoo();
+}


### PR DESCRIPTION
Adds an API to allow configuring include and exclude patterns on `sourceDir` entries in the Gradle plugin extension.

@jparise please take a look and let me know whether this addresses your use-case.  You're welcome to comment on anything here but probably the most interesting thing will be the readme changes which document the new API, and its direct implementation in `ThriftyExtension.kt` should you be so inclined.

Fixes #365