### PR TITLE
Bump shadow-jar from 5.2.0 -> 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.11.1'
     }
 }


### PR DESCRIPTION
This fixes that "deprecated Gradle features" warning on each build.