### PR TITLE
Remove all Kotlin uses of mocks in unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ allprojects {
 
                 testing: [
                         'junit:junit:4.12',
-                        'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',
                         'com.google.truth:truth:1.0.1',
                         'org.hamcrest:hamcrest-all:1.3',
                         dependencies.create('io.kotest:kotest-assertions-jvm:4.0.5') {

--- a/thrifty-runtime/build.gradle
+++ b/thrifty-runtime/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     api libraries.okio
 
     testImplementation libraries.testing
+    testImplementation 'org.mockito:mockito-core:2.23.0'
 }
 
 checkstyle {

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/ConstantTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/ConstantTest.kt
@@ -32,8 +32,6 @@ import com.microsoft.thrifty.schema.parser.LiteralValueElement
 import com.microsoft.thrifty.schema.parser.ScalarTypeElement
 import com.microsoft.thrifty.schema.parser.TypeElement
 import com.microsoft.thrifty.schema.parser.TypedefElement
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Test
 
 import org.hamcrest.CoreMatchers.containsString
@@ -42,8 +40,24 @@ import org.junit.Assert.assertThat
 import org.junit.Assert.fail
 
 class ConstantTest {
-    private val symbolTable: SymbolTable = mock()
+    private val symbolTable = TestSymbolTable()
     private val loc = Location.get("", "")
+
+    private class TestSymbolTable : SymbolTable {
+        private val symbols = mutableMapOf<String, Constant>()
+
+        operator fun get(name: String): Constant? {
+            return symbols[name]
+        }
+
+        operator fun set(name: String, constant: Constant) {
+            symbols[name] = constant
+        }
+
+        override fun lookupConst(symbol: String): Constant? {
+            return get(symbol)
+        }
+    }
 
     @Test
     fun boolLiteral() {
@@ -67,7 +81,7 @@ class ConstantTest {
                 IdentifierValueElement(loc, "aBool", "aBool"),
                 BuiltinType.BOOL)
 
-        whenever(symbolTable.lookupConst("aBool")).thenReturn(c)
+        symbolTable["aBool"] = c
 
         Constant.validate(symbolTable, IdentifierValueElement(loc, "aBool", "aBool"), BuiltinType.BOOL)
     }
@@ -80,7 +94,7 @@ class ConstantTest {
                 IdentifierValueElement(loc, "aBool", "abool"),
                 BuiltinType.STRING)
 
-        whenever(symbolTable.lookupConst("aBool")).thenReturn(c)
+        symbolTable["aBool"] = c
 
         try {
             Constant.validate(symbolTable, IdentifierValueElement(loc, "aBool", "aBool"), BuiltinType.BOOL)
@@ -113,7 +127,7 @@ class ConstantTest {
                 IdentifierValueElement(loc, "aBool", "aBool"),
                 td)
 
-        whenever(symbolTable.lookupConst("aBool")).thenReturn(c)
+        symbolTable["aBool"] = c
 
         Constant.validate(symbolTable, IdentifierValueElement(loc, "aBool", "aBool"), BuiltinType.BOOL)
     }
@@ -187,7 +201,7 @@ class ConstantTest {
                 IdentifierValueElement(loc, "aDouble", "aDouble"),
                 BuiltinType.DOUBLE)
 
-        whenever(symbolTable.lookupConst("aDouble")).thenReturn(c)
+        symbolTable["aDouble"] = c
 
         Constant.validate(symbolTable, IdentifierValueElement(loc, "aDouble", "aDouble"), BuiltinType.DOUBLE)
     }
@@ -200,7 +214,7 @@ class ConstantTest {
                 IdentifierValueElement(loc, "aString", "aString"),
                 BuiltinType.STRING)
 
-        whenever(symbolTable.lookupConst("aString")).thenReturn(c)
+        symbolTable["aString"] = c
 
         try {
             Constant.validate(symbolTable, IdentifierValueElement(loc, "aString", "aString"), BuiltinType.DOUBLE)

--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/FieldTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/FieldTest.kt
@@ -25,7 +25,6 @@ import com.microsoft.thrifty.schema.parser.AnnotationElement
 import com.microsoft.thrifty.schema.parser.FieldElement
 import com.microsoft.thrifty.schema.parser.ScalarTypeElement
 import com.microsoft.thrifty.schema.parser.TypeElement
-import com.nhaarman.mockitokotlin2.mock
 import org.junit.Test
 
 import java.util.Collections
@@ -138,7 +137,7 @@ class FieldTest {
         val field = Field(fieldElement, emptyMap())
 
         val annotations = ImmutableMap.of<String, String>()
-        val thriftType = mock<ThriftType>()
+        val thriftType = BuiltinType.DOUBLE
 
         val builderField = field.toBuilder()
                 .annotations(annotations)


### PR DESCRIPTION
This stuff (Kotlin adaptations of mockito) is constantly breaking, and we don't really need it.

The Java tests rely much more heavily on mockito, and as stable as that code is I don't see a need to rip it out.