### PR TITLE
Introducing flag to add a required builder constructor

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -246,6 +246,12 @@ class ThriftyCompiler {
                     "--kt-file-per-type", help = "Generate one .kt file per type; default is one per namespace.")
                 .flag(default = false)
 
+        val kotlinBuilderRequiredConstructor: Boolean by option("--experimental-kt-builder-required-ctor")
+                .flag(default = false)
+
+        val kotlinBuilderOmitEmptyConstructor: Boolean by option("--experimental-kt-builder-omit-empty-ctor")
+                .flag(default = false)
+
         val kotlinBuilderlessDataClasses: Boolean by option("--experimental-kt-builderless-structs")
                 .flag(default = false)
 
@@ -299,6 +305,8 @@ class ThriftyCompiler {
 
             val impliedLanguage = when {
                 kotlinBuilderlessDataClasses -> Language.KOTLIN
+                kotlinBuilderRequiredConstructor -> Language.KOTLIN
+                kotlinBuilderOmitEmptyConstructor -> Language.KOTLIN
                 kotlinFilePerType -> Language.KOTLIN
                 nullabilityAnnotationType != NullabilityAnnotationType.NONE -> Language.JAVA
                 else -> null
@@ -376,6 +384,14 @@ class ThriftyCompiler {
 
             if (kotlinBuilderlessDataClasses) {
                 gen.builderlessDataClasses()
+            }
+
+            if (kotlinBuilderRequiredConstructor) {
+                gen.builderRequiredConstructor()
+            }
+
+            if (kotlinBuilderOmitEmptyConstructor) {
+                gen.omitBuilderEmptyConstructor()
             }
 
             if (kotlinCoroutineClients) {

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -249,9 +249,6 @@ class ThriftyCompiler {
         val kotlinBuilderRequiredConstructor: Boolean by option("--experimental-kt-builder-required-ctor")
                 .flag(default = false)
 
-        val kotlinBuilderOmitEmptyConstructor: Boolean by option("--experimental-kt-builder-omit-empty-ctor")
-                .flag(default = false)
-
         val kotlinBuilderlessDataClasses: Boolean by option("--experimental-kt-builderless-structs")
                 .flag(default = false)
 
@@ -306,7 +303,6 @@ class ThriftyCompiler {
             val impliedLanguage = when {
                 kotlinBuilderlessDataClasses -> Language.KOTLIN
                 kotlinBuilderRequiredConstructor -> Language.KOTLIN
-                kotlinBuilderOmitEmptyConstructor -> Language.KOTLIN
                 kotlinFilePerType -> Language.KOTLIN
                 nullabilityAnnotationType != NullabilityAnnotationType.NONE -> Language.JAVA
                 else -> null
@@ -388,10 +384,6 @@ class ThriftyCompiler {
 
             if (kotlinBuilderRequiredConstructor) {
                 gen.builderRequiredConstructor()
-            }
-
-            if (kotlinBuilderOmitEmptyConstructor) {
-                gen.omitBuilderEmptyConstructor()
             }
 
             if (kotlinCoroutineClients) {

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -130,6 +130,11 @@ import java.util.ArrayList
  * will not compile on Java versions that do not have this annotation.  Because Thrifty is intended
  * for use on Android, we default to jdk8 (Android doesn't support JDK9 and probably never* will).
  *
+ * `--experimental-kt-builder-required-ctor` is optional. When specified, Generate struct Builder
+ * constructor with required parameters, and marks empty Builder constructor as deprecated. Helpful
+ * when needing a compile time check that required parameters are supplied to the struct. This
+ * also marks the empty Builder constructor as deprecated in favor of the required one
+ *
  * If no .thrift files are given, then all .thrift files located on the search path
  * will be implicitly included; otherwise only the given files (and those included by them)
  * will be compiled.
@@ -246,7 +251,8 @@ class ThriftyCompiler {
                     "--kt-file-per-type", help = "Generate one .kt file per type; default is one per namespace.")
                 .flag(default = false)
 
-        val kotlinBuilderRequiredConstructor: Boolean by option("--experimental-kt-builder-required-ctor")
+        val kotlinBuilderRequiredConstructor: Boolean by option("--experimental-kt-builder-required-ctor",
+                    help = "Generate struct Builder constructor with required parameters, and mark empty Builder constructor as deprecated")
                 .flag(default = false)
 
         val kotlinBuilderlessDataClasses: Boolean by option("--experimental-kt-builderless-structs")

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -832,6 +832,7 @@ class KotlinCodeGenerator(
 
         if (builderRequiredConstructor && requiredCtor.parameters.isNotEmpty()) {
             spec.addFunction(requiredCtor.build())
+            defaultCtor.addAnnotation(makeEmptyConstructorDeprecated(requiredCtor.parameters))
         }
 
         return spec
@@ -2281,6 +2282,15 @@ class KotlinCodeGenerator(
     private fun makeDeprecated(): AnnotationSpec {
         return AnnotationSpec.builder(Deprecated::class)
                 .addMember("message = %S", "Deprecated in source .thrift")
+                .build()
+    }
+
+    private fun makeEmptyConstructorDeprecated(params: MutableList<ParameterSpec>): AnnotationSpec {
+        var parameterString = params.joinToString(prefix = "Builder(", postfix = ")", separator = ", ") { it.name }
+
+        return AnnotationSpec.builder(Deprecated::class)
+                .addMember("message = %S", "Empty constructor deprectated, use required constructor instead")
+                .addMember("replaceWith = ReplaceWith(%S)", parameterString)
                 .build()
     }
 

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -123,7 +123,6 @@ class KotlinCodeGenerator(
     private var parcelize: Boolean = false
     private var builderlessDataClasses: Boolean = false
     private var builderRequiredConstructor: Boolean = false
-    private var omitBuilderEmptyConstructor: Boolean = false
     private var omitServiceClients: Boolean = false
     private var coroutineServiceClients: Boolean = false
     private var emitJvmName: Boolean = false
@@ -222,10 +221,6 @@ class KotlinCodeGenerator(
 
     fun builderRequiredConstructor(): KotlinCodeGenerator = apply {
         this.builderRequiredConstructor = true
-    }
-
-    fun omitBuilderEmptyConstructor(): KotlinCodeGenerator = apply {
-        this.omitBuilderEmptyConstructor = true
     }
 
     fun omitServiceClients(): KotlinCodeGenerator = apply {
@@ -839,11 +834,8 @@ class KotlinCodeGenerator(
             spec.addFunction(requiredCtor.build())
         }
 
-        if (!omitBuilderEmptyConstructor) {
-            spec.addFunction(defaultCtor.build())
-        }
-
         return spec
+                .addFunction(defaultCtor.build())
                 .addFunction(buildFunSpec.build())
                 .addFunction(copyCtor.build())
                 .addFunction(resetFunSpec.build())

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -835,7 +835,7 @@ class KotlinCodeGenerator(
                 .addCode(buildParamStringBuilder.toString())
                 .addCode(")»")
 
-        if (builderRequiredConstructor) {
+        if (builderRequiredConstructor && requiredCtor.parameters.isNotEmpty()) {
             spec.addFunction(requiredCtor.build())
         }
 

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -970,27 +970,7 @@ class KotlinCodeGeneratorTest {
         val file = generate(thrift) { builderRequiredConstructor() }
         file.single().toString() shouldContain expected
     }
-
-    @Test
-    fun `omit empty builder constructor`() {
-        val thrift = """
-            |namespace kt test.struct
-            |
-            |
-            |struct TestStruct {
-            |  1: required i64 field1;
-            |}
-        """.trimMargin()
-
-        val expectedNotPresent = """
-    constructor() {
-      this.field1 = null
-    }"""
-
-        val file = generate(thrift) { omitBuilderEmptyConstructor() }
-        file.single().toString() shouldNotContain expectedNotPresent
-    }
-
+    
     private fun generate(thrift: String, config: (KotlinCodeGenerator.() -> KotlinCodeGenerator)? = null): List<FileSpec> {
         val configOrDefault = config ?: { this }
         return KotlinCodeGenerator()

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -1002,11 +1002,7 @@ class KotlinCodeGeneratorTest {
             |}
         """.trimMargin()
 
-        val notExpected = """
-    @Deprecated(
-      message = "Empty constructor deprectated, use required constructor instead",
-      replaceWith = ReplaceWith("Builder(field1)")
-    )"""
+        val notExpected = "@Deprecated("
 
         val expected = """
     constructor() {


### PR DESCRIPTION
Currently, the only enforcement of required properties in a struct is in the ".build()" final methods of the StructBuilder. This change adds a flag to build a struct builder constructor consisting of the required fields that have not yet been statically defined in thrift. This provides a compile time enforcement of required properties for a struct.

Additionally, to fully enforce the required builder paradigm, we need to add an option to get rid of the empty constructor within the builder. The combination of these two flags should create a struct that will always have its required properties populated in addition to the null validation on build().