### PR TITLE
Fix Kotlin builderless structs with fields named 'result'

### DIFF
--- a/thrifty-integration-tests/CoroutineClientTest.thrift
+++ b/thrifty-integration-tests/CoroutineClientTest.thrift
@@ -307,3 +307,10 @@ service ThriftTest
   UnionWithDefault testUnionWithDefault(1: UnionWithDefault theArg)
 }
 
+// Builderless unions should handle fields named "result".
+// see https://github.com/microsoft/thrifty/issues/404
+union UnionWithResult {
+  1: i32 result;
+  2: i64 bigResult;
+  3: string error;
+}


### PR DESCRIPTION
Fixes #404