### PR TITLE
Add Okio-based convenience APIs to thrifty-runtime

### DIFF
--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/CoroutineConformanceTests.kt
@@ -21,6 +21,8 @@
 package com.microsoft.thrifty.integration.conformance
 
 import com.microsoft.thrifty.ThriftException
+import com.microsoft.thrifty.binaryProtocol
+import com.microsoft.thrifty.compactProtocol
 import com.microsoft.thrifty.integration.kgen.coro.Bonk
 import com.microsoft.thrifty.integration.kgen.coro.HasUnion
 import com.microsoft.thrifty.integration.kgen.coro.Insanity
@@ -32,9 +34,7 @@ import com.microsoft.thrifty.integration.kgen.coro.Xception
 import com.microsoft.thrifty.integration.kgen.coro.Xception2
 import com.microsoft.thrifty.integration.kgen.coro.Xtruct
 import com.microsoft.thrifty.integration.kgen.coro.Xtruct2
-import com.microsoft.thrifty.protocol.BinaryProtocol
-import com.microsoft.thrifty.protocol.CompactProtocol
-import com.microsoft.thrifty.protocol.JsonProtocol
+import com.microsoft.thrifty.jsonProtocol
 import com.microsoft.thrifty.protocol.Protocol
 import com.microsoft.thrifty.service.AsyncClientBase
 import com.microsoft.thrifty.testing.ServerProtocol
@@ -103,9 +103,9 @@ abstract class CoroutineConformanceTests(
 
     private fun createProtocol(transport: Transport): Protocol {
         return when (serverProtocol) {
-            ServerProtocol.BINARY -> BinaryProtocol(transport)
-            ServerProtocol.COMPACT -> CompactProtocol(transport)
-            ServerProtocol.JSON -> JsonProtocol(transport)
+            ServerProtocol.BINARY -> transport.binaryProtocol()
+            ServerProtocol.COMPACT -> transport.compactProtocol()
+            ServerProtocol.JSON -> transport.jsonProtocol()
         }
     }
 

--- a/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
+++ b/thrifty-integration-tests/src/test/kotlin/com/microsoft/thrifty/integration/conformance/KotlinConformanceTest.kt
@@ -21,6 +21,8 @@
 package com.microsoft.thrifty.integration.conformance
 
 import com.microsoft.thrifty.ThriftException
+import com.microsoft.thrifty.binaryProtocol
+import com.microsoft.thrifty.compactProtocol
 import com.microsoft.thrifty.integration.kgen.HasUnion
 import com.microsoft.thrifty.integration.kgen.Insanity
 import com.microsoft.thrifty.integration.kgen.NonEmptyUnion
@@ -32,9 +34,7 @@ import com.microsoft.thrifty.integration.kgen.Xception
 import com.microsoft.thrifty.integration.kgen.Xception2
 import com.microsoft.thrifty.integration.kgen.Xtruct
 import com.microsoft.thrifty.integration.kgen.Xtruct2
-import com.microsoft.thrifty.protocol.BinaryProtocol
-import com.microsoft.thrifty.protocol.CompactProtocol
-import com.microsoft.thrifty.protocol.JsonProtocol
+import com.microsoft.thrifty.jsonProtocol
 import com.microsoft.thrifty.protocol.Protocol
 import com.microsoft.thrifty.service.AsyncClientBase
 import com.microsoft.thrifty.testing.ServerProtocol
@@ -103,9 +103,9 @@ abstract class KotlinConformanceTest(
 
     private fun createProtocol(transport: Transport): Protocol {
         return when (serverProtocol) {
-            ServerProtocol.BINARY -> BinaryProtocol(transport)
-            ServerProtocol.COMPACT -> CompactProtocol(transport)
-            ServerProtocol.JSON -> JsonProtocol(transport)
+            ServerProtocol.BINARY -> transport.binaryProtocol()
+            ServerProtocol.COMPACT -> transport.compactProtocol()
+            ServerProtocol.JSON -> transport.jsonProtocol()
         }
     }
 

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/KtApi.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/KtApi.kt
@@ -1,0 +1,83 @@
+package com.microsoft.thrifty
+
+import com.microsoft.thrifty.protocol.BinaryProtocol
+import com.microsoft.thrifty.protocol.CompactProtocol
+import com.microsoft.thrifty.protocol.JsonProtocol
+import com.microsoft.thrifty.protocol.SimpleJsonProtocol
+import com.microsoft.thrifty.transport.BufferTransport
+import com.microsoft.thrifty.transport.Transport
+import okio.Buffer
+import okio.BufferedSink
+import okio.BufferedSource
+
+/**
+ * Creates a transport backed by the given [Buffer].
+ *
+ * @receiver the [Buffer] backing the new transport.
+ * @return a transport that reads from/writes to the buffer.
+ */
+fun Buffer.transport() = BufferTransport(this)
+
+/**
+ * Creates a read-only transport from the given [BufferedSource].
+ *
+ * @receiver the source underlying the new transport.
+ * @return a read-only transport.
+ */
+fun <S : BufferedSource> S.transport() = object : Transport {
+    private val self = this@transport
+
+    override fun close() = self.close()
+
+    override fun read(buffer: ByteArray, offset: Int, count: Int) = self.read(buffer, offset, count)
+
+    override fun write(data: ByteArray) = error("read-only transport")
+
+    override fun write(buffer: ByteArray, offset: Int, count: Int) = error("read-only transport")
+
+    override fun flush() {
+        // No-op
+    }
+}
+
+/**
+ * Creates a write-only transport from the given [BufferedSink]
+ *
+ * @receiver the sink underlying the new transport.
+ * @return a write-only transport.
+ */
+fun <S : BufferedSink> S.transport() = object : Transport {
+    private val self = this@transport
+
+    override fun close() = self.close()
+
+    override fun read(buffer: ByteArray, offset: Int, count: Int) = error("write-only transport")
+
+    override fun write(data: ByteArray) { self.write(data) }
+
+    override fun write(buffer: ByteArray, offset: Int, count: Int) {
+        self.write(buffer, offset, count)
+    }
+
+    override fun flush() = self.flush()
+}
+
+/**
+ * Creates a [BinaryProtocol] from the given [Transport].
+ */
+fun <T : Transport> T.binaryProtocol() = BinaryProtocol(this)
+
+/**
+ * Creates a [CompactProtocol] from the given [Transport].
+ */
+fun <T : Transport> T.compactProtocol() = CompactProtocol(this)
+
+/**
+ * Creates a [JsonProtocol] from the given [Transport].
+ */
+fun <T : Transport> T.jsonProtocol() = JsonProtocol(this)
+
+/**
+ * Creates a [SimpleJsonProtocol] from the given [Transport].
+ */
+fun <T : Transport> T.simpleJsonProtocol() = SimpleJsonProtocol(this)


### PR DESCRIPTION
This adds extensions to `BufferedSource` and `BufferedSink`, making it easy to convert them into thrifty `Transport` objects in a fluent style.  It also adds fluent builders for making `Protocol` instances out of `Transport` instances.  This lets us do the following:

```kt
val someBigThriftObject = ...

File("/tmp/example.bin")
    .sink()
    .buffer()
    .transport()
    .binaryProtocol()
    .use(someBigThriftObject::write)
```

In contrast, before this PR one would have to either write a custom transport, or buffer the entire serialized message in memory:

```kt
val someBigThriftObject = ...
val buffer = Buffer()
someBigThriftObject.write(BinaryProtocol(BufferTransport(buffer)))
// buffer now holds the entire serialized 

File("/tmp/example.bin")
    .sink()
    .use() { it.write(buffer, buffer.size) }
```

The new code is about as brief as the old code, is more easily readable (IMO), and has the potential to be much more efficient in that it can partake in okio's segment-sharing and stream reads and writes rather than buffering entire messages into memory at once.  In some real-world use cases this is a savings of MB per message of working memory.

It's clearly not hard to write these custom transports, but there's no need for everyone to have to do it themselves.