### PR TITLE
Make AsyncClientBase into an 'expect' class

### DIFF
--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
@@ -1,0 +1,60 @@
+package com.microsoft.thrifty.service
+
+import com.microsoft.thrifty.internal.Closeable
+import com.microsoft.thrifty.protocol.Protocol
+
+/**
+ * Implements a basic service client that executes methods asynchronously.
+ *
+ * Note that, while the client-facing API of this class is callback-based,
+ * the implementation itself is **blocking**.  Unlike the Apache
+ * implementation, there is no presumption made here about framed encoding
+ * at the transport level.  If your backend requires framing, be sure to
+ * configure your [Protocol] and [com.microsoft.thrifty.transport.Transport]
+ * objects appropriately.
+ *
+ * @param protocol the [Protocol] used to encode/decode requests and responses.
+ * @param listener a callback object to receive client-level events.
+ */
+expect open class AsyncClientBase protected constructor(
+    protocol: Protocol,
+    listener: Listener
+) : ClientBase, Closeable {
+    /**
+     * Exposes important events in the client's lifecycle.
+     */
+    interface Listener {
+        /**
+         * Invoked when the client connection has been closed.
+         *
+         * After invocation, the client is no longer usable.  All subsequent
+         * method call attempts will result in an immediate exception on the
+         * calling thread.
+         */
+        fun onTransportClosed()
+
+        /**
+         * Invoked when a client-level error has occurred.
+         *
+         * This generally indicates a connectivity or protocol error,
+         * and is distinct from errors returned as part of normal service
+         * operation.
+         *
+         * The client is guaranteed to have been closed and shut down
+         * by the time this method is invoked.
+         *
+         * @param error the throwable instance representing the error.
+         */
+        fun onError(error: Throwable)
+    }
+
+    /**
+     * Enqueues a method call for asynchronous execution.
+     *
+     * WARNING:
+     * This method is *NOT* part of the public API.  It is an implementation
+     * detail, for use by generated code only.  As multi-platform code evolves,
+     * expect this to change and/or be removed entirely!
+     */
+    protected fun enqueue(methodCall: MethodCall<*>)
+}

--- a/thrifty-runtime/src/jvmMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
+++ b/thrifty-runtime/src/jvmMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
@@ -42,14 +42,14 @@ import java.util.concurrent.RejectedExecutionException
  * objects appropriately.
  */
 @Suppress("UNCHECKED_CAST")
-open class AsyncClientBase protected constructor(
+actual open class AsyncClientBase protected actual constructor(
         protocol: Protocol,
         private val listener: Listener
 ) : ClientBase(protocol), Closeable {
     /**
      * Exposes important events in the client's lifecycle.
      */
-    interface Listener {
+    actual interface Listener {
         /**
          * Invoked when the client connection has been closed.
          *
@@ -58,7 +58,7 @@ open class AsyncClientBase protected constructor(
          * method call attempts will result in an immediate exception on the
          * calling thread.
          */
-        fun onTransportClosed()
+        actual fun onTransportClosed()
 
         /**
          * Invoked when a client-level error has occurred.
@@ -74,7 +74,7 @@ open class AsyncClientBase protected constructor(
          *
          * @param error the throwable instance representing the error.
          */
-        fun onError(error: Throwable)
+        actual fun onError(error: Throwable)
     }
 
     /**
@@ -99,7 +99,7 @@ open class AsyncClientBase protected constructor(
      *
      * @param methodCall the remote method call to be invoked
      */
-    protected fun enqueue(methodCall: MethodCall<*>) {
+    protected actual fun enqueue(methodCall: MethodCall<*>) {
         check(running.get()) { "Cannot write to a closed service client" }
         check(pendingCalls.offer(methodCall)) {
             // This should never happen with an unbounded queue


### PR DESCRIPTION
As part of #401, we need to remove JVM-only references from generated code.  The only such type that we own is `AsyncClientBase`, heretofore a JVM-only type due to its use of threads.

This PR creates an `expect class AsyncClientBase` capturing the salient parts of the interface - a constructor, a `Listener`, and a protected `enqueue` method - and makes the JVM type an `actual`.