### PR TITLE
Use kotlin.collections typealiases of java.util types by default

### DIFF
--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -128,6 +128,10 @@ class KotlinCodeGenerator(
     private var emitJvmName: Boolean = false
     private var failOnUnknownEnumValues: Boolean = true
 
+    private val defaultListClassName: ClassName = ClassName("kotlin.collections", "ArrayList")
+    private val defaultSetClassName: ClassName = ClassName("kotlin.collections", "LinkedHashSet")
+    private val defaultMapClassName: ClassName = ClassName("kotlin.collections", "LinkedHashMap")
+
     private var listClassName: ClassName? = null
     private var setClassName: ClassName? = null
     private var mapClassName: ClassName? = null
@@ -1406,7 +1410,7 @@ class KotlinCodeGenerator(
 
             override fun visitList(listType: ListType) {
                 val elementType = listType.elementType
-                val listImplClassName = listClassName ?: ArrayList::class.asClassName()
+                val listImplClassName = listClassName ?: defaultListClassName
                 val listImplType = listImplClassName.parameterizedBy(elementType.typeName)
                 val listMeta = if (localNamePrefix.isNotEmpty()) {
                     "${localNamePrefix}_list$scope"
@@ -1431,7 +1435,7 @@ class KotlinCodeGenerator(
 
             override fun visitSet(setType: SetType) {
                 val elementType = setType.elementType
-                val setImplClassName = setClassName ?: LinkedHashSet::class.asClassName()
+                val setImplClassName = setClassName ?: defaultSetClassName
                 val setImplType = setImplClassName.parameterizedBy(elementType.typeName)
                 val setMeta = if (localNamePrefix.isNotEmpty()) {
                     "${localNamePrefix}_set$scope"
@@ -1458,7 +1462,7 @@ class KotlinCodeGenerator(
             override fun visitMap(mapType: MapType) {
                 val keyType = mapType.keyType
                 val valType = mapType.valueType
-                val mapImplClassName = mapClassName ?: LinkedHashMap::class.asClassName()
+                val mapImplClassName = mapClassName ?: defaultMapClassName
                 val mapImplType = mapImplClassName.parameterizedBy(keyType.typeName, valType.typeName)
                 val mapMeta = if (localNamePrefix.isNotEmpty()) {
                     "${localNamePrefix}_map$scope"

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -1015,6 +1015,32 @@ class KotlinCodeGeneratorTest {
         file.single().toString() shouldNotContain notExpected
     }
 
+    @Test
+    fun `collection types do not use Java collections by default`() {
+        val thrift = """
+            |namespace kt test.lists
+            |
+            |const list<i32> FOO = [1, 2, 3];
+            |const map<i8, i8> BAR = { 1: 2 };
+            |const set<string> BAZ = ["foo", "bar", "baz"];
+            |
+            |struct HasCollections {
+            |  1: list<string> strs;
+            |  2: map<string, string> more_strs;
+            |  3: set<i16> shorts;
+            |}
+            |
+            |service HasListMethodArg {
+            |  list<i8> sendThatList(1: list<i8> byteList);
+            |}
+        """.trimMargin()
+
+        for (file in generate(thrift)) {
+            val kt = file.toString()
+            kt shouldNotContain "java.util"
+        }
+    }
+
     private fun generate(thrift: String, config: (KotlinCodeGenerator.() -> KotlinCodeGenerator)? = null): List<FileSpec> {
         val configOrDefault = config ?: { this }
         return KotlinCodeGenerator()


### PR DESCRIPTION
Part of the #401 effort.  This PR removes references to `java.util` collection types by default in generated Kotlin code.