### PR TITLE
Location.base should always be an include root

### DIFF
--- a/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/LoaderTest.kt
+++ b/thrifty-schema/src/test/kotlin/com/microsoft/thrifty/schema/LoaderTest.kt
@@ -224,7 +224,7 @@ class LoaderTest {
         """
 
         val b = """
-            include '${f1.canonicalPath}'
+            include 'nested/a.thrift'
             namespace java com.microsoft.thrifty.test.crazyIncludes
 
             struct B {
@@ -233,7 +233,7 @@ class LoaderTest {
         """
 
         val c = """
-            include '${f2.canonicalPath}'
+            include 'b.thrift'
 
             namespace java com.microsoft.thrifty.test.crazyIncludes
 
@@ -247,14 +247,15 @@ class LoaderTest {
         f3.writeText(c)
 
         val loader = Loader()
-        loader.addIncludePath(nestedDir.toPath())
-        loader.addThriftFile(f2.toPath())
-        loader.addThriftFile(f3.toPath())
+        loader.addIncludePath(tempDir.toPath())
 
         val schema = loader.load()
 
         schema.structs shouldHaveSize 2
         schema.enums shouldHaveSize 1
+
+        val enum = schema.enums.single()
+        enum.location.path shouldBe "nested/a.thrift"
     }
 
     @Test


### PR DESCRIPTION
As far as I can tell, Location has always been busted in practice - `base`, intended to be a "root" of some kind, has always been the full path to a file's parent directory, and "path" (intended to be a path relative to base) has just been a file name.

This makes Location little better than a string with line numbers in it - not all that useful.  In this PR, we fix what turns out to be the sole location (outside of tests) where Locations are created.  We do this by, when loading files from disk to parse, cycling through all of our include-roots, looking for the one with the shortest relative distance between the root and the file being loaded.

This isn't bulletproof since thrift files can include relative paths, and so potentially include files that aren't contained in any of our roots.  In that case, we'll keep the current behavior of calling the file's directory the location base.

This also isn't ideal - you could argue that, if a file under root A relatively includes a file under root B, and that included file wouldn't have otherwise been part of the compilation, that maybe A is the more useful attribution.  In the name of implementation simplicity, I disclaim that use case :)

@jparise I'd be grateful for your thoughts, if you've got the time and inclination.

Fixes #237