### PR TITLE
Make JvmStatic opt-in and fix an erroneous usage

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -58,6 +58,7 @@ import java.util.ArrayList
  * [--lang=[java|kotlin]]
  * [--kt-file-per-type]
  * [--kt-struct-builders]
+ * [--kt-jvm-static]
  * [--parcelable]
  * [--use-android-annotations]
  * [--nullability-annotation-type=[none|android-support|androidx]]
@@ -97,6 +98,10 @@ import java.util.ArrayList
  * with inner 'Builder' classes, in the same manner as Java code.  The Kotlin default is
  * to use pure data classes.  This option is for retaining compatibility in codebases using
  * older Thrifty versions, and should be avoided in new code.
+ *
+ * `--kt-jvm-static` is optional.  When specified, certain companion-object functions will
+ * be annotated with [JvmStatic].  This option is for those who want easier Java interop,
+ * and results in slightly larger code.
  *
  * `--parcelable` is optional.  When provided, generated types will contain a
  * `Parcelable` implementation.  Kotlin types will use the `@Parcelize` extension.
@@ -210,6 +215,9 @@ class ThriftyCompiler {
         val kotlinStructBuilders: Boolean by option("--kt-struct-builders")
                 .flag("--kt-no-struct-builders", default = false)
 
+        val kotlinEmitJvmStatic: Boolean by option("--kt-jvm-static")
+                .flag("--kt-no-jvm-static", default = false)
+
         val kotlinCoroutineClients: Boolean by option("--kt-coroutine-clients")
                 .flag(default = false)
 
@@ -253,6 +261,7 @@ class ThriftyCompiler {
                 kotlinFilePerType -> Language.KOTLIN
                 kotlinCoroutineClients -> Language.KOTLIN
                 kotlinEmitJvmName -> Language.KOTLIN
+                kotlinEmitJvmStatic -> Language.KOTLIN
                 nullabilityAnnotationType != NullabilityAnnotationType.NONE -> Language.JAVA
                 else -> null
             }
@@ -311,6 +320,10 @@ class ThriftyCompiler {
 
             if (kotlinEmitJvmName) {
                 gen.emitJvmName()
+            }
+
+            if (kotlinEmitJvmStatic) {
+                gen.emitJvmStatic()
             }
 
             if (kotlinFilePerType) {

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -87,6 +87,7 @@ def kompileCoroutineTestThrift = tasks.register("kompileCoroutineTestThrift", Ja
             "--out=$projectDir/build/generated-src/thrifty/kotlin",
             "--lang=kotlin",
             "--kt-coroutine-clients",
+            "--kt-file-per-type",
             "$projectDir/CoroutineClientTest.thrift"
     ]
 }

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -139,6 +139,7 @@ class KotlinCodeGenerator(
     private var omitServiceClients: Boolean = false
     private var coroutineServiceClients: Boolean = false
     private var emitJvmName: Boolean = false
+    private var emitJvmStatic: Boolean = false
     private var failOnUnknownEnumValues: Boolean = true
 
     private var listClassName: ClassName? = null
@@ -247,6 +248,10 @@ class KotlinCodeGenerator(
 
     fun emitJvmName(): KotlinCodeGenerator = apply {
         this.emitJvmName = true
+    }
+
+    fun emitJvmStatic(): KotlinCodeGenerator = apply {
+        this.emitJvmStatic = true
     }
 
     fun failOnUnknownEnumValues(value: Boolean = true): KotlinCodeGenerator = apply {
@@ -388,7 +393,7 @@ class KotlinCodeGenerator(
         val findByValue = FunSpec.builder("findByValue")
                 .addParameter("value", INT)
                 .returns(enumType.typeName.copy(nullable = true))
-                .jvmStatic()
+                .apply { if (emitJvmStatic) jvmStatic() }
                 .beginControlFlow("return when (value)")
 
         val nameAllocator = nameAllocators[enumType]
@@ -655,7 +660,7 @@ class KotlinCodeGenerator(
             val defaultValue = field.defaultValue!!
             val renderedValue = renderConstValue(schema, field.type, defaultValue)
             val propBuilder = PropertySpec.builder("DEFAULT", structClassName)
-                    .jvmStatic()
+                    .jvmField()
                     .initializer("%T(%L)", defaultValueTypeName, renderedValue)
 
             companionBuilder.addProperty(propBuilder.build())

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -810,7 +810,7 @@ class KotlinCodeGeneratorTest {
         val file = generate(thrift)
 
         file.single().toString() should contain("""
-            |    @JvmStatic
+            |    @JvmField
             |    val DEFAULT: HasDefault = Int(16)
         """.trimMargin())
     }


### PR DESCRIPTION
All this time I've mistakenly believed that `@JvmStatic` _converts_ a companion-object method into a bona-fide static method.  That turns out to be untrue.  What it does is add a second static method to the parent class that loads the companion object and calls the annotated method.

R8 optimizes this away, but not everybody uses R8.  Since we're moving more and more to a Kotlin-only future, and in the service of (slightly) smaller code, this PR makes `@JvmStatic` opt-in only via a compiler flag.

It also fixes an erroneous usage of `@JvmStatic`, where `@JvmField` is the correct and intended annotation.