### PR TITLE
Adding support for alternative Kotlin enum generation

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -59,7 +59,7 @@ import java.util.ArrayList
  * [--kt-file-per-type]
  * [--kt-struct-builders]
  * [--kt-jvm-static]
- * [--kt-big-enum]
+ * [--kt-big-enums]
  * [--parcelable]
  * [--use-android-annotations]
  * [--nullability-annotation-type=[none|android-support|androidx]]
@@ -87,6 +87,7 @@ import java.util.ArrayList
  * class name when instantiating map-typed values.  Defaults to [java.util.HashMap].
  * Android users will likely wish to substitute `android.support.v4.util.ArrayMap`.
  *
+ * `--lang=[java|kotlin]` is optional, defaulting to Java.  When provided, the
  * compiler will generate code in the specified language.
  *
  * `--kt-file-per-type` is optional.  When specified, one Kotlin file will be generated

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -59,6 +59,7 @@ import java.util.ArrayList
  * [--kt-file-per-type]
  * [--kt-struct-builders]
  * [--kt-jvm-static]
+ * [--kt-big-enum]
  * [--parcelable]
  * [--use-android-annotations]
  * [--nullability-annotation-type=[none|android-support|androidx]]
@@ -86,7 +87,6 @@ import java.util.ArrayList
  * class name when instantiating map-typed values.  Defaults to [java.util.HashMap].
  * Android users will likely wish to substitute `android.support.v4.util.ArrayMap`.
  *
- * `--lang=[java|kotlin]` is optional, defaulting to Java.  When provided, the
  * compiler will generate code in the specified language.
  *
  * `--kt-file-per-type` is optional.  When specified, one Kotlin file will be generated
@@ -218,6 +218,9 @@ class ThriftyCompiler {
         val kotlinEmitJvmStatic: Boolean by option("--kt-jvm-static")
                 .flag("--kt-no-jvm-static", default = false)
 
+        val kotlinBigEnums: Boolean by option("--kt-big-enums")
+                .flag("--kt-no-big-enums", default = false)
+
         val kotlinCoroutineClients: Boolean by option("--kt-coroutine-clients")
                 .flag(default = false)
 
@@ -262,6 +265,7 @@ class ThriftyCompiler {
                 kotlinCoroutineClients -> Language.KOTLIN
                 kotlinEmitJvmName -> Language.KOTLIN
                 kotlinEmitJvmStatic -> Language.KOTLIN
+                kotlinBigEnums -> Language.KOTLIN
                 nullabilityAnnotationType != NullabilityAnnotationType.NONE -> Language.JAVA
                 else -> null
             }
@@ -324,6 +328,10 @@ class ThriftyCompiler {
 
             if (kotlinEmitJvmStatic) {
                 gen.emitJvmStatic()
+            }
+
+            if (kotlinBigEnums) {
+                gen.emitBigEnums()
             }
 
             if (kotlinFilePerType) {


### PR DESCRIPTION
When generating very very large enums, the generated code will fail to compile due to JVM code-size limits (see #406).

This PR (based on #407) adds a compiler flag to use an alternative method to generate Kotlin enum classes, which works around this limitation by removing the `value` member and instead adds a `value()` function to map an enum to its Int value. 

Since this flag also generates a `value` property which calls through to the `value()` function, this change can be done transparently to Kotlin callers.