### PR TITLE
Okio 2.8.0 -> 2.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,10 @@ allprojects {
                 ],
 
                 okio: [
-                        'com.squareup.okio:okio:2.8.0'
+                        'com.squareup.okio:okio:2.10.0'
                 ],
 
-                okioMulti: 'com.squareup.okio:okio-multiplatform:2.8.0',
+                okioMulti: 'com.squareup.okio:okio-multiplatform:2.10.0',
 
                 testing: [
                         "org.junit.jupiter:junit-jupiter:5.6.2",

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/internal/-Platform.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/internal/-Platform.kt
@@ -27,8 +27,4 @@ expect annotation class DefaultMethod()
 
 expect class ProtocolException(message: String) : IOException
 
-expect interface Closeable {
-    fun close()
-}
-
 expect val DefaultDispatcher: CoroutineDispatcher

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/protocol/Protocol.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/protocol/Protocol.kt
@@ -20,9 +20,9 @@
  */
 package com.microsoft.thrifty.protocol
 
-import com.microsoft.thrifty.internal.Closeable
 import com.microsoft.thrifty.internal.DefaultMethod
 import okio.ByteString
+import okio.Closeable
 import okio.IOException
 
 interface Protocol : Closeable {

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/AsyncClientBase.kt
@@ -1,7 +1,7 @@
 package com.microsoft.thrifty.service
 
-import com.microsoft.thrifty.internal.Closeable
 import com.microsoft.thrifty.protocol.Protocol
+import okio.Closeable
 
 /**
  * Implements a basic service client that executes methods asynchronously.

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/ClientBase.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/service/ClientBase.kt
@@ -25,8 +25,8 @@ import com.microsoft.thrifty.ThriftException
 import com.microsoft.thrifty.ThriftException.Companion.read
 import com.microsoft.thrifty.internal.AtomicBoolean
 import com.microsoft.thrifty.internal.AtomicInteger
-import com.microsoft.thrifty.internal.Closeable
 import com.microsoft.thrifty.protocol.Protocol
+import okio.Closeable
 import okio.IOException
 
 /**

--- a/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/transport/Transport.kt
+++ b/thrifty-runtime/src/commonMain/kotlin/com/microsoft/thrifty/transport/Transport.kt
@@ -20,8 +20,8 @@
  */
 package com.microsoft.thrifty.transport
 
-import com.microsoft.thrifty.internal.Closeable
 import com.microsoft.thrifty.internal.DefaultMethod
+import okio.Closeable
 import okio.IOException
 
 interface Transport : Closeable {

--- a/thrifty-runtime/src/jvmMain/kotlin/com/microsoft/thrifty/internal/-Platform.kt
+++ b/thrifty-runtime/src/jvmMain/kotlin/com/microsoft/thrifty/internal/-Platform.kt
@@ -27,6 +27,4 @@ actual typealias DefaultMethod = JvmDefault
 
 actual typealias ProtocolException = java.net.ProtocolException
 
-actual typealias Closeable = java.io.Closeable
-
 actual val DefaultDispatcher: CoroutineDispatcher = Dispatchers.IO


### PR DESCRIPTION
They added an `okio.Closeable` expect interface, so we can remove ours and use theirs.