### PR TITLE
Fix builder class generating name clash if union contains field named "error"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ allprojects {
                             exclude module: 'kotlin-stdlib'
                             exclude module: 'kotlin-reflect'
                         },
+                        dependencies.create('io.kotest:kotest-assertions-compiler:4.0.5') {
+                            exclude module: 'kotlin-stdlib'
+                            exclude module: 'kotlin-reflect'
+                        },
                         dependencies.platform("org.jetbrains.kotlin:kotlin-bom:$kotlin_version"),
                 ]
         ]

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -915,8 +915,9 @@ class KotlinCodeGenerator(
                         .addModifiers(KModifier.OVERRIDE)
                         .returns(structTypeName)
                         .addStatement(
-                                "return %N ?: error(%S)",
+                                "return %N ?: %M(%S)",
                                 builderVarName,
+                                MemberName("kotlin", "error"),
                                 "Invalid union; at least one value is required")
                         .build())
                 .addFunction(FunSpec.builder("reset")

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -191,6 +191,21 @@ class KotlinCodeGeneratorTest {
         xception.propertySpecs.single().name shouldBe "message_"
     }
 
+
+    @Test
+    fun `union with error as field name should compile with builder`() {
+        val thrift = """
+            namespace kt com.test
+
+            union Fail { 1: string error }
+        """.trimIndent()
+
+        val specs = generate(thrift) {
+            withDataClassBuilders()
+        }
+        specs.shouldCompile()
+    }
+
     @Test
     fun services() {
         val thrift = """

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -84,6 +84,7 @@ class KotlinCodeGeneratorTest {
 
         val files = KotlinCodeGenerator(FieldNamingPolicy.JAVA).generate(schema)
 
+        files.shouldCompile()
         files.forEach { println("$it") }
     }
 
@@ -127,6 +128,7 @@ class KotlinCodeGeneratorTest {
         val gen = KotlinCodeGenerator().filePerType()
         val specs = gen.generate(schema)
 
+        specs.shouldCompile()
         specs.single().name shouldBe "Constants" // ".kt" suffix is appended when the file is written out
     }
 
@@ -139,6 +141,7 @@ class KotlinCodeGeneratorTest {
         """.trimIndent()
 
         val specs = generate(thrift)
+        specs.shouldCompile()
 
         val struct = specs.single().members.single() as TypeSpec
 
@@ -162,6 +165,7 @@ class KotlinCodeGeneratorTest {
         """.trimIndent()
 
         val specs = generate(thrift)
+        specs.shouldCompile()
 
         val struct = specs.single().members.single() as TypeSpec
 
@@ -182,6 +186,7 @@ class KotlinCodeGeneratorTest {
 
         val schema = load(thrift)
         val specs = KotlinCodeGenerator(FieldNamingPolicy.JAVA).generate(schema)
+        specs.shouldCompile()
         val xception = specs.single().members.single() as TypeSpec
         xception.propertySpecs.single().name shouldBe "message_"
     }
@@ -201,7 +206,9 @@ class KotlinCodeGeneratorTest {
             }
         """.trimIndent()
 
-        generate(thrift).forEach { println(it) }
+        val specs = generate(thrift)
+        specs.shouldCompile()
+        specs.forEach { println(it) }
     }
 
     @Test
@@ -216,7 +223,9 @@ class KotlinCodeGeneratorTest {
             }
         """.trimIndent()
 
-        generate(thrift).forEach { println(it) }
+        val specs = generate(thrift)
+        specs.shouldCompile()
+        specs.forEach { println(it) }
     }
 
     @Test
@@ -231,6 +240,7 @@ class KotlinCodeGeneratorTest {
         """.trimIndent()
 
         val file = generate(thrift).single()
+        file.shouldCompile()
         val svc = file.members.first { it is TypeSpec && it.name == "Foo" } as TypeSpec
         val method = svc.funSpecs.single()
         method.name shouldBe "doIt"
@@ -328,6 +338,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { coroutineServiceClients() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |public interface Svc {
@@ -376,14 +387,14 @@ class KotlinCodeGeneratorTest {
             |const i32 FooNum = 42
         """.trimMargin()
 
-        val text = generate(thrift) {
-                    emitJvmName()
-                    filePerNamespace()
-                }
+        val file = generate(thrift) {
+            emitJvmName()
+            filePerNamespace()
+        }
                 .single()
-                .toString()
+        file.shouldCompile()
 
-        text shouldBe """
+        file.toString() shouldBe """
             |@file:JvmName("ThriftTypes")
             |
             |package test.consts
@@ -404,14 +415,14 @@ class KotlinCodeGeneratorTest {
             |const i32 FooNum = 42
         """.trimMargin()
 
-        val text = generate(thrift) {
-                    emitJvmName()
-                    filePerType()
-                }
+        val file = generate(thrift) {
+            emitJvmName()
+            filePerType()
+        }
                 .single()
-                .toString()
+        file.shouldCompile()
 
-        text shouldBe """
+        file.toString() shouldBe """
             |@file:JvmName("Constants")
             |
             |package test.consts
@@ -438,6 +449,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { coroutineServiceClients() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |sealed class Union : Struct {
@@ -458,6 +470,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { coroutineServiceClients() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |
@@ -502,6 +515,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |  public class Builder : StructBuilder<Union> {
@@ -545,6 +559,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift)
+        file.shouldCompile()
 
         file.single().toString() shouldNot contain("""
             |    class Builder
@@ -565,6 +580,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) //{ shouldImplementStruct() }
+        file.shouldCompile()
 
         file.single().toString() shouldNot contain("""
             |  : Struct
@@ -589,6 +605,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |    public override fun read(protocol: Protocol) = read(protocol, Builder())
@@ -657,7 +674,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift)
-
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |    public override fun read(protocol: Protocol): Union {
@@ -725,6 +742,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |  private class UnionAdapter : Adapter<Union, Builder> {
@@ -745,6 +763,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift)
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |  private class UnionAdapter : Adapter<Union> {
@@ -761,6 +780,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { coroutineServiceClients() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |class Union : Struct {
@@ -783,6 +803,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |public sealed class UnionStruct : Struct {
@@ -814,6 +835,7 @@ class KotlinCodeGeneratorTest {
         """.trimIndent()
 
         val file = generate(thrift)
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |    @JvmField
@@ -833,6 +855,7 @@ class KotlinCodeGeneratorTest {
         """.trimMargin()
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
 
         file.single().toString() should contain("""
             |    public override fun build(): Bonk = Bonk(message = this.message, type = this.type)
@@ -866,6 +889,7 @@ class KotlinCodeGeneratorTest {
           }"""
 
         val file = generate(thrift) { withDataClassBuilders() }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
     }
 
@@ -912,6 +936,7 @@ class KotlinCodeGeneratorTest {
             withDataClassBuilders()
             failOnUnknownEnumValues(false)
         }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
     }
 
@@ -955,6 +980,7 @@ class KotlinCodeGeneratorTest {
           }"""
 
         val file = generate(thrift) { failOnUnknownEnumValues(false) }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
     }
 
@@ -979,6 +1005,7 @@ class KotlinCodeGeneratorTest {
             withDataClassBuilders()
             builderRequiredConstructor()
         }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
     }
 
@@ -1003,6 +1030,7 @@ class KotlinCodeGeneratorTest {
             withDataClassBuilders()
             builderRequiredConstructor()
         }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
     }
 
@@ -1029,6 +1057,7 @@ class KotlinCodeGeneratorTest {
             withDataClassBuilders()
             builderRequiredConstructor()
         }
+        file.shouldCompile()
         file.single().toString() shouldContain expected
         file.single().toString() shouldNotContain notExpected
     }

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/util.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/util.kt
@@ -1,0 +1,15 @@
+package com.microsoft.thrifty.kgen
+
+import com.squareup.kotlinpoet.FileSpec
+import io.kotest.matchers.compilation.shouldCompile
+
+fun List<FileSpec>.shouldCompile() {
+    forEach {
+        it.shouldCompile()
+    }
+}
+
+fun FileSpec.shouldCompile() {
+    toString().lineSequence().forEachIndexed { index, s -> println("${(index+1).toString().padStart(4)}: $s") }
+    toString().shouldCompile()
+}


### PR DESCRIPTION
Unfortunately, there seems to be an upstream bug in addition to the missing fully qualified reference to kotlin.error in the code generator.

Or do you have an idea why my fix would not work?