### PR TITLE
Remove jcenter, finally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,12 +95,11 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        jcenter() // for dokka only - ugh
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30"
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.20'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.30'
         classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
     }


### PR DESCRIPTION
Dokka is finally available on Maven Central, along with its dependencies.  That was our last remaining dependency on jcenter, and now we can finally be rid of them.