### PR TITLE
Added huge enum generation

### DIFF
--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -126,7 +126,8 @@ import kotlin.system.exitProcess
  * `--kt-huge-enums` is optional.  When specified, generated enums will use a different
  * representation. Instead of `enum class`, a hierarchy of enum-like classes will be generated
  * that is syntactically equivalent to access from Kotlin  This should
- * be avoided unless you know you need it.  Implies `--lang=kotlin`.
+ * be avoided unless you know you need it.  Implies `--lang=kotlin` and mutually-exclusive with
+ * `--kt-big-enums`.
  *
  * `--parcelable` is optional.  When provided, generated types will contain a
  * `Parcelable` implementation.  Kotlin types will use the `@Parcelize` extension.

--- a/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
+++ b/thrifty-compiler/src/main/kotlin/com/microsoft/thrifty/compiler/ThriftyCompiler.kt
@@ -64,7 +64,7 @@ import kotlin.system.exitProcess
  * [--kt-struct-builders]
  * [--kt-jvm-static]
  * [--kt-big-enums]
- * [--kt-huge-enum]
+ * [--kt-huge-enums]
  * [--parcelable]
  * [--use-android-annotations]
  * [--nullability-annotation-type=[none|android-support|androidx]]
@@ -120,10 +120,12 @@ import kotlin.system.exitProcess
  * representation.  Rather than each enum member containing its value, a single large
  * function mapping enums to values will be generated.  This works around some JVM class-size
  * limitations in some extreme cases, such as an enum with thousands of members.  This should
- * be avoided unless you know you need it.  Implies `--lang=kotlin`.
+ * be avoided unless you know you need it.  Implies `--lang=kotlin` and mutually-exclusive with
+ * `--kt-huge-enums`.
  *
  * `--kt-huge-enums` is optional.  When specified, generated enums will use a different
- * representation. FILL THIS OUT This should
+ * representation. Instead of `enum class`, a hierarchy of enum-like classes will be generated
+ * that is syntactically equivalent to access from Kotlin  This should
  * be avoided unless you know you need it.  Implies `--lang=kotlin`.
  *
  * `--parcelable` is optional.  When provided, generated types will contain a

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -594,18 +594,19 @@ class KotlinCodeGenerator(
                 FunSpec.builder("findByValue")
                     .addParameter("value", Int::class)
                     .returns(enumType.typeName.copy(nullable = true))
-                    .jvmStatic()
+                    .apply { if (emitJvmStatic) jvmStatic() }
                     .addStatement(
                         "return %T.findByValue(value)",
                         lastParentClass
                     )
                     .build()
             )
+        // For smoother Java compatibility, every enum value has to be declared in the final 'enum' class
         enumType.members.forEach { member ->
             companion.addProperty(
                 PropertySpec.builder(member.name, enumType.typeName)
                     .initializer("`%L`", member.name.toGeneratedMemberName())
-                    .jvmField()
+                    .apply { if (emitJvmStatic) jvmField() }
                     .build()
             )
         }


### PR DESCRIPTION
For very very large enums, even the `--kt-big-enum` workaround is not enough to avoid the Java code size limits, so we've added a `--kt-huge-enum` option which generates a hierarchy of enum-like classes that are syntactically equivalent to Kotlin the `enum class`. 