### PR TITLE
Bump to Kotlin 1.5.32

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ POM_DEVELOPER_URL=https://www.bendb.com
 # Dokka is a greedy little pig
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 
-KOTLIN_VERSION=1.4.31
+KOTLIN_VERSION=1.5.32

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'com.gradle.plugin-publish' version '0.12.0'
         id 'com.github.johnrengelman.shadow' version '6.1.0'
         id 'com.vanniktech.maven.publish' version '0.17.0'
-        id 'org.jetbrains.dokka' version '1.4.30'
+        id 'org.jetbrains.dokka' version '1.6.10'
         id 'org.jetbrains.kotlin.jvm' version "${KOTLIN_VERSION}"
     }
 }
@@ -44,7 +44,7 @@ dependencyResolutionManagement {
             alias('kotlin-reflect').to('org.jetbrains.kotlin', 'kotlin-reflect').versionRef('kotlin')
             alias('kotlin-stdlib').to('org.jetbrains.kotlin', 'kotlin-stdlib-jdk8').versionRef('kotlin')
             alias('kotlin-stdlibCommon').to('org.jetbrains.kotlin', 'kotlin-stdlib-common').versionRef('kotlin')
-            alias('kotlinx-coroutines').to('org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.3.9')
+            alias('kotlinx-coroutines').to('org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.5.2')
             alias('kotlinPoet').to('com.squareup', 'kotlinpoet').version('1.8.0')
             alias('okio').to('com.squareup.okio', 'okio').versionRef('okio')
             alias('okioMulti').to('com.squareup.okio', 'okio-multiplatform').versionRef('okio')

--- a/thrifty-example-postprocessor/build.gradle
+++ b/thrifty-example-postprocessor/build.gradle
@@ -33,9 +33,11 @@ dependencies {
 jar {
     archiveFileName.set('compiler.jar')
 
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
     // Include dependencies in the final JAR
     from {
-        (configurations.runtime).collect() {
+        (configurations.runtimeClasspath).collect() {
             it.isDirectory() ? it : zipTree(it)
         }
     }

--- a/thrifty-runtime/build.gradle
+++ b/thrifty-runtime/build.gradle
@@ -44,7 +44,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings {
-                useExperimentalAnnotation("kotlin.ExperimentalMultiplatform")
+                optIn("kotlin.ExperimentalMultiplatform")
             }
         }
 

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
@@ -166,6 +166,8 @@ class Constant private constructor (
                         return
                     }
                 }
+
+                else -> {}
             }
 
             throw IllegalStateException(


### PR DESCRIPTION
This one is squirrely.  Initially I attempted to bump to Kotlin 1.6.10 but encountered some vexing bugs with our thrifty-runtime MPP setup and Gradle's variant-selection (what's that you ask?  I didn't know, either.).  

Downgrading to 1.5.32 resolved the issue.

During that brief moment when I had 1.6 configured, I got a warning about non-exhaustive `when` statements over types being deprecated, so I added an empty `else` branch to the one instance in the project.

Finally, a few bits of our project seem to have rotted - the example post-processor build broke in an interesting way, possibly due to me running Java 11?  Either way, easy to address.