### PR TITLE
Upgrade to Kotlin  1.6.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ POM_DEVELOPER_URL=https://www.bendb.com
 # Dokka is a greedy little pig
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 
-KOTLIN_VERSION=1.5.32
+KOTLIN_VERSION=1.6.10

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ pluginManagement {
         id 'com.vanniktech.maven.publish' version '0.17.0'
         id 'org.jetbrains.dokka' version '1.6.10'
         id 'org.jetbrains.kotlin.jvm' version "${KOTLIN_VERSION}"
+        id 'org.jetbrains.kotlin.multiplatform' version "${KOTLIN_VERSION}"
     }
 }
 
@@ -30,10 +31,10 @@ dependencyResolutionManagement {
     versionCatalogs {
         deps {
             version('kotlin', "${KOTLIN_VERSION}")
-            version('okio', '2.10.0')
+            version('okio', '3.0.0')
 
             version('junit', '5.7.1')
-            version('kotest', '4.4.1')
+            version('kotest', '5.1.0')
 
             alias('antlr').to('org.antlr', 'antlr4').version('4.9.1')
             alias('apacheThrift').to('org.apache.thrift', 'libthrift').version('0.12.0')
@@ -44,10 +45,9 @@ dependencyResolutionManagement {
             alias('kotlin-reflect').to('org.jetbrains.kotlin', 'kotlin-reflect').versionRef('kotlin')
             alias('kotlin-stdlib').to('org.jetbrains.kotlin', 'kotlin-stdlib-jdk8').versionRef('kotlin')
             alias('kotlin-stdlibCommon').to('org.jetbrains.kotlin', 'kotlin-stdlib-common').versionRef('kotlin')
-            alias('kotlinx-coroutines').to('org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.5.2')
+            alias('kotlinx-coroutines').to('org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.6.0')
             alias('kotlinPoet').to('com.squareup', 'kotlinpoet').version('1.8.0')
             alias('okio').to('com.squareup.okio', 'okio').versionRef('okio')
-            alias('okioMulti').to('com.squareup.okio', 'okio-multiplatform').versionRef('okio')
 
             bundle('kotlin', ['kotlin-stdlib', 'kotlin-reflect'])
 
@@ -57,7 +57,7 @@ dependencyResolutionManagement {
             alias('kotest-assertions-common').to('io.kotest', 'kotest-common').versionRef('kotest')
             alias('kotest-assertions-core').to('io.kotest', 'kotest-assertions-core').versionRef('kotest')
             alias('kotest-assertions-coreJvm').to('io.kotest', 'kotest-assertions-core-jvm').versionRef('kotest')
-            alias('kotest-assertions-compiler').to('io.kotest', 'kotest-assertions-compiler').versionRef('kotest')
+            alias('kotest-assertions-compiler').to('io.kotest.extensions', 'kotest-assertions-compiler').version('1.0.0') // They forgot to publish newer binaries
 
             alias('kotlin-test-common').to('org.jetbrains.kotlin', 'kotlin-test-common').versionRef('kotlin')
             alias('kotlin-test-annotations-common').to('org.jetbrains.kotlin', 'kotlin-test-annotations-common').versionRef('kotlin')

--- a/thrifty-runtime/build.gradle
+++ b/thrifty-runtime/build.gradle
@@ -19,6 +19,9 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
 plugins {
     id 'thrifty-jvm-module'
     id 'org.jetbrains.kotlin.multiplatform'
@@ -51,7 +54,7 @@ kotlin {
         commonMain {
             dependencies {
                 api deps.kotlin.stdlibCommon
-                api deps.okioMulti
+                api deps.okio
                 api deps.kotlinx.coroutines
             }
         }
@@ -80,4 +83,23 @@ kotlin {
 
 jvmTest {
     useJUnitPlatform()
+}
+
+// What have I gotten myself in to
+configurations {
+    jvmApiElements {
+        attributes {
+            attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, "external"))
+        }
+    }
+
+    jvmRuntimeElements {
+        attributes {
+            attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, "external"))
+        }
+    }
 }


### PR DESCRIPTION
This one's a doozy.  For whatever reason, Kotlin 1.6 induces a Gradle issue where pure-Java modules (`thrifty-kotlin-codegen`, `thrifty-compiler`, etc) can no longer properly reference the mutliplatform `thrifty-runtime` project.  Something to do with ambiguous variants - oh by the way, did you know Grade modules have variants? - with names like `apiElements` vs `jvmApiElements`.

Documentation on this area of Gradle is sparse.  I _think_ the right thing to do is to advertise slightly different attributes for the JVM-specific variants, but honestly am not sure.