### PR TITLE
Bump Kotlin to 1.6.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ POM_DEVELOPER_URL=https://www.bendb.com
 # Dokka is a greedy little pig
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 
-KOTLIN_VERSION=1.6.10
+KOTLIN_VERSION=1.6.20

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,12 +58,13 @@ dependencyResolutionManagement {
             alias('kotest-assertions-core').to('io.kotest', 'kotest-assertions-core').versionRef('kotest')
             alias('kotest-assertions-coreJvm').to('io.kotest', 'kotest-assertions-core-jvm').versionRef('kotest')
             alias('kotest-assertions-compiler').to('io.kotest.extensions', 'kotest-assertions-compiler').version('1.0.0') // They forgot to publish newer binaries
+            alias('kotlin-compile-testing').to('com.github.tschuchortdev', 'kotlin-compile-testing').version('1.4.8')
 
             alias('kotlin-test-common').to('org.jetbrains.kotlin', 'kotlin-test-common').versionRef('kotlin')
             alias('kotlin-test-annotations-common').to('org.jetbrains.kotlin', 'kotlin-test-annotations-common').versionRef('kotlin')
             alias('kotlin-test-junit5').to('org.jetbrains.kotlin', 'kotlin-test-junit5').versionRef('kotlin')
 
-            bundle('testing', ['junit', 'hamcrest', 'kotest-assertions-core', 'kotest-assertions-coreJvm', 'kotest-assertions-compiler'])
+            bundle('testing', ['junit', 'hamcrest', 'kotest-assertions-core', 'kotest-assertions-coreJvm', 'kotest-assertions-compiler', 'kotlin-compile-testing'])
         }
     }
 }


### PR DESCRIPTION
Slightly complicated by the fact that `kotest-assertions-compile` seems to have fallen into disrepair (pot, kettle, I know); most of its actual logic is in `com.github.tschuchortdev:kotlin-compile-testing`, and it so happens that by requesting a newer version of that dependency, tests work.  Fragile, but good enough for the moment.

I'll probably regret that and end up writing our own kotest/kotlin-compile-testing integration, but not today!