### PR TITLE
Fix various Gradle deprecations around version catalogs

### DIFF
--- a/buildSrc/src/main/groovy/thrifty-kotlin-module.gradle
+++ b/buildSrc/src/main/groovy/thrifty-kotlin-module.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 dependencies {
-    api platform(deps.kotlin.bom)
+    api platform(libs.kotlin.bom)
 }
 
 tasks.named('compileKotlin').configure {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,6 @@ pluginManagement {
     }
 }
 
-enableFeaturePreview('VERSION_CATALOGS')
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 
@@ -29,40 +27,40 @@ dependencyResolutionManagement {
     }
 
     versionCatalogs {
-        deps {
+        libs {
             version('kotlin', "${KOTLIN_VERSION}")
             version('okio', '3.0.0')
 
             version('junit', '5.7.1')
             version('kotest', '5.1.0')
 
-            alias('antlr').to('org.antlr', 'antlr4').version('4.9.1')
-            alias('apacheThrift').to('org.apache.thrift', 'libthrift').version('0.12.0')
-            alias('clikt').to('com.github.ajalt.clikt', 'clikt').version('3.1.0')
-            alias('guava').to('com.google.guava', 'guava').version('29.0-jre')
-            alias('javaPoet').to('com.squareup', 'javapoet').version('1.13.0')
-            alias('kotlin-bom').to('org.jetbrains.kotlin', 'kotlin-bom').versionRef('kotlin')
-            alias('kotlin-reflect').to('org.jetbrains.kotlin', 'kotlin-reflect').versionRef('kotlin')
-            alias('kotlin-stdlib').to('org.jetbrains.kotlin', 'kotlin-stdlib-jdk8').versionRef('kotlin')
-            alias('kotlin-stdlibCommon').to('org.jetbrains.kotlin', 'kotlin-stdlib-common').versionRef('kotlin')
-            alias('kotlinx-coroutines').to('org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.6.0')
-            alias('kotlinPoet').to('com.squareup', 'kotlinpoet').version('1.8.0')
-            alias('okio').to('com.squareup.okio', 'okio').versionRef('okio')
+            library('antlr', 'org.antlr', 'antlr4').version('4.9.1')
+            library('apacheThrift', 'org.apache.thrift', 'libthrift').version('0.12.0')
+            library('clikt', 'com.github.ajalt.clikt', 'clikt').version('3.1.0')
+            library('guava', 'com.google.guava', 'guava').version('29.0-jre')
+            library('javaPoet', 'com.squareup', 'javapoet').version('1.13.0')
+            library('kotlin-bom', 'org.jetbrains.kotlin', 'kotlin-bom').versionRef('kotlin')
+            library('kotlin-reflect', 'org.jetbrains.kotlin', 'kotlin-reflect').versionRef('kotlin')
+            library('kotlin-stdlib', 'org.jetbrains.kotlin', 'kotlin-stdlib-jdk8').versionRef('kotlin')
+            library('kotlin-stdlibCommon', 'org.jetbrains.kotlin', 'kotlin-stdlib-common').versionRef('kotlin')
+            library('kotlinx-coroutines', 'org.jetbrains.kotlinx', 'kotlinx-coroutines-core').version('1.6.0')
+            library('kotlinPoet', 'com.squareup', 'kotlinpoet').version('1.8.0')
+            library('okio', 'com.squareup.okio', 'okio').versionRef('okio')
 
             bundle('kotlin', ['kotlin-stdlib', 'kotlin-reflect'])
 
-            alias('junit').to('org.junit.jupiter', 'junit-jupiter').versionRef('junit')
-            alias('junitApi').to('org.junit.jupiter', 'junit-jupiter-api').versionRef('junit')
-            alias('hamcrest').to('org.hamcrest', 'hamcrest').version('2.2')
-            alias('kotest-assertions-common').to('io.kotest', 'kotest-common').versionRef('kotest')
-            alias('kotest-assertions-core').to('io.kotest', 'kotest-assertions-core').versionRef('kotest')
-            alias('kotest-assertions-coreJvm').to('io.kotest', 'kotest-assertions-core-jvm').versionRef('kotest')
-            alias('kotest-assertions-compiler').to('io.kotest.extensions', 'kotest-assertions-compiler').version('1.0.0') // They forgot to publish newer binaries
-            alias('kotlin-compile-testing').to('com.github.tschuchortdev', 'kotlin-compile-testing').version('1.4.8')
+            library('junit', 'org.junit.jupiter', 'junit-jupiter').versionRef('junit')
+            library('junitApi', 'org.junit.jupiter', 'junit-jupiter-api').versionRef('junit')
+            library('hamcrest', 'org.hamcrest', 'hamcrest').version('2.2')
+            library('kotest-assertions-common', 'io.kotest', 'kotest-common').versionRef('kotest')
+            library('kotest-assertions-core', 'io.kotest', 'kotest-assertions-core').versionRef('kotest')
+            library('kotest-assertions-coreJvm', 'io.kotest', 'kotest-assertions-core-jvm').versionRef('kotest')
+            library('kotest-assertions-compiler', 'io.kotest.extensions', 'kotest-assertions-compiler').version('1.0.0') // They forgot to publish newer binaries
+            library('kotlin-compile-testing', 'com.github.tschuchortdev', 'kotlin-compile-testing').version('1.4.8')
 
-            alias('kotlin-test-common').to('org.jetbrains.kotlin', 'kotlin-test-common').versionRef('kotlin')
-            alias('kotlin-test-annotations-common').to('org.jetbrains.kotlin', 'kotlin-test-annotations-common').versionRef('kotlin')
-            alias('kotlin-test-junit5').to('org.jetbrains.kotlin', 'kotlin-test-junit5').versionRef('kotlin')
+            library('kotlin-test-common', 'org.jetbrains.kotlin', 'kotlin-test-common').versionRef('kotlin')
+            library('kotlin-test-annotations-common', 'org.jetbrains.kotlin', 'kotlin-test-annotations-common').versionRef('kotlin')
+            library('kotlin-test-junit5', 'org.jetbrains.kotlin', 'kotlin-test-junit5').versionRef('kotlin')
 
             bundle('testing', ['junit', 'hamcrest', 'kotest-assertions-core', 'kotest-assertions-coreJvm', 'kotest-assertions-compiler', 'kotlin-compile-testing'])
         }

--- a/thrifty-compiler-plugins/build.gradle
+++ b/thrifty-compiler-plugins/build.gradle
@@ -25,6 +25,6 @@ plugins {
 }
 
 dependencies {
-    api deps.javaPoet
-    api deps.kotlinPoet
+    api libs.javaPoet
+    api libs.kotlinPoet
 }

--- a/thrifty-compiler/build.gradle
+++ b/thrifty-compiler/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation project(':thrifty-kotlin-codegen')
     implementation project(':thrifty-compiler-plugins')
 
-    implementation deps.clikt
-    implementation deps.bundles.kotlin
+    implementation libs.clikt
+    implementation libs.bundles.kotlin
 }
 
 sourceSets {

--- a/thrifty-example-postprocessor/build.gradle
+++ b/thrifty-example-postprocessor/build.gradle
@@ -24,10 +24,10 @@ plugins {
 
 dependencies {
     implementation project(':thrifty-compiler-plugins')
-    implementation deps.javaPoet
+    implementation libs.javaPoet
 
-    implementation deps.bundles.kotlin
-    implementation deps.kotlinPoet
+    implementation libs.bundles.kotlin
+    implementation libs.kotlinPoet
 }
 
 jar {

--- a/thrifty-gradle-plugin/build.gradle
+++ b/thrifty-gradle-plugin/build.gradle
@@ -79,10 +79,10 @@ dependencies {
     compileOnly project(':thrifty-kotlin-codegen')
     compileOnly project(':thrifty-schema')
 
-    implementation deps.guava
+    implementation libs.guava
 
-    testImplementation deps.junit
-    testImplementation deps.hamcrest
+    testImplementation libs.junit
+    testImplementation libs.hamcrest
 }
 
 def installLocal = tasks.register("installForTesting") {

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -30,10 +30,10 @@ dependencies {
 
     testImplementation project(':thrifty-runtime')
     testImplementation project(':thrifty-test-server')
-    testImplementation deps.guava
+    testImplementation libs.guava
 
-    testImplementation deps.bundles.kotlin
-    testImplementation deps.bundles.testing
+    testImplementation libs.bundles.kotlin
+    testImplementation libs.bundles.testing
 
     implementation 'org.apache.thrift:libthrift:0.12.0'
 }

--- a/thrifty-java-codegen/build.gradle
+++ b/thrifty-java-codegen/build.gradle
@@ -29,12 +29,12 @@ description = 'Converts Thrifty Schemas into Java source files'
 dependencies {
     api project(":thrifty-schema")
     api project(":thrifty-compiler-plugins")
-    api deps.okio
-    api deps.javaPoet
+    api libs.okio
+    api libs.javaPoet
 
-    api deps.bundles.kotlin
+    api libs.bundles.kotlin
 
     implementation project(':thrifty-runtime')
 
-    testImplementation deps.bundles.testing
+    testImplementation libs.bundles.testing
 }

--- a/thrifty-kotlin-codegen/build.gradle
+++ b/thrifty-kotlin-codegen/build.gradle
@@ -29,13 +29,12 @@ description = 'Converts Thrifty Schemas into Kotlin source files'
 dependencies {
     api project(":thrifty-schema")
     api project(":thrifty-compiler-plugins")
-    api deps.bundles.kotlin
-    api deps.okio
+    api libs.bundles.kotlin
+    api libs.okio
 
     implementation project(':thrifty-runtime')
-    implementation deps.kotlinPoet
+    implementation libs.kotlinPoet
 
-    testImplementation deps.bundles.kotlin
-    testImplementation deps.bundles.testing
-    testImplementation 'com.github.tschuchortdev:kotlin-compile-testing:1.4.2'
+    testImplementation libs.bundles.kotlin
+    testImplementation libs.bundles.testing
 }

--- a/thrifty-runtime/build.gradle
+++ b/thrifty-runtime/build.gradle
@@ -53,18 +53,18 @@ kotlin {
 
         commonMain {
             dependencies {
-                api deps.kotlin.stdlibCommon
-                api deps.okio
-                api deps.kotlinx.coroutines
+                api libs.kotlin.stdlibCommon
+                api libs.okio
+                api libs.kotlinx.coroutines
             }
         }
 
         commonTest {
             dependencies {
-                implementation deps.kotlin.test.common
-                implementation deps.kotlin.test.annotations.common
-                implementation deps.kotest.assertions.common
-                implementation deps.kotest.assertions.core
+                implementation libs.kotlin.test.common
+                implementation libs.kotlin.test.annotations.common
+                implementation libs.kotest.assertions.common
+                implementation libs.kotest.assertions.core
             }
         }
 
@@ -73,9 +73,9 @@ kotlin {
 
         jvmTest {
             dependencies {
-                implementation deps.kotlin.test.junit5
-                implementation deps.kotest.assertions.coreJvm
-                implementation deps.junit
+                implementation libs.kotlin.test.junit5
+                implementation libs.kotest.assertions.coreJvm
+                implementation libs.junit
             }
         }
     }

--- a/thrifty-schema/build.gradle
+++ b/thrifty-schema/build.gradle
@@ -31,15 +31,15 @@ generateGrammarSource {
 }
 
 dependencies {
-    antlr deps.antlr
-    implementation deps.antlr
+    antlr libs.antlr
+    implementation libs.antlr
 
-    api deps.guava
-    api deps.bundles.kotlin
+    api libs.guava
+    api libs.bundles.kotlin
 
-    implementation deps.okio
+    implementation libs.okio
 
-    testImplementation deps.bundles.testing
+    testImplementation libs.bundles.testing
 }
 
 // For some reason, Kotlin compilation is being run prior to antlr by default.

--- a/thrifty-test-server/build.gradle
+++ b/thrifty-test-server/build.gradle
@@ -23,6 +23,6 @@ plugins {
 }
 
 dependencies {
-    api deps.junitApi
-    implementation deps.apacheThrift
+    api libs.junitApi
+    implementation libs.apacheThrift
 }


### PR DESCRIPTION
Gradle's warning about a few deprecated constructs in our version-catalog setup:
- all catalog names will soon be required to end in `libs`.  We're swimming upstream so I'm just naming it `libs`.
- the `alias` method is deprecated in favor of either `library` or `plugin`.  we aren't using catalogs for plugins so this is a simple rename.

Also, dropping an unexpected literal dependency on `kotlin-compile-testing` in `:thrifty-kotlin-codegen`, since that's explicitly pulled in now by `libs.bundles.testing`.