### PR TITLE
Fix more Kotlin deprecations and warnings

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ServiceBuilder.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ServiceBuilder.kt
@@ -34,6 +34,7 @@ import com.squareup.javapoet.NameAllocator
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
+import java.util.Locale
 
 import javax.lang.model.element.Modifier
 import java.util.concurrent.atomic.AtomicInteger
@@ -162,7 +163,7 @@ internal class ServiceBuilder(
     }
 
     private fun buildCallSpec(method: ServiceMethod): TypeSpec {
-        val name = "${method.name.capitalize()}Call"
+        val name = "${method.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}Call"
 
         val returnType = method.returnType
         val returnTypeName = if (returnType == BuiltinType.VOID) {

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
@@ -195,7 +195,7 @@ class Constant private constructor (
                 }
             } else {
                 throw IllegalStateException(
-                        "Expected a value of type ${expected.name.toLowerCase()} but got $valueElement")
+                        "Expected a value of type ${expected.name.lowercase()} but got $valueElement")
             }
         }
     }

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/FieldNamingPolicy.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/FieldNamingPolicy.kt
@@ -109,15 +109,15 @@ abstract class FieldNamingPolicy {
          */
         private fun caseFormatOf(s: String): CaseFormat? {
             if (s.contains("_")) {
-                if (s.toUpperCase() == s) {
+                if (s.uppercase() == s) {
                     return CaseFormat.UPPER_UNDERSCORE
                 }
 
-                if (s.toLowerCase() == s) {
+                if (s.lowercase() == s) {
                     return CaseFormat.LOWER_UNDERSCORE
                 }
             } else if (s.contains("-")) {
-                if (s.toLowerCase() == s) {
+                if (s.lowercase() == s) {
                     return CaseFormat.LOWER_HYPHEN
                 }
             } else {

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElementMixin.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/UserElementMixin.kt
@@ -113,7 +113,7 @@ internal data class UserElementMixin(
     fun hasThriftOrJavadocAnnotation(name: String): Boolean {
         return (annotations.containsKey(name)
                 || annotations.containsKey("thrifty.$name")
-                || hasJavadoc && documentation.toLowerCase(Locale.US).contains("@$name"))
+                || hasJavadoc && documentation.lowercase(Locale.US).contains("@$name"))
     }
 
     override fun toString(): String {


### PR DESCRIPTION
More fixes for `toUpperCase()`, `toLowerCase()`, and `capitalize()`, in addition to fixing some (new?) warnings.