### PR TITLE
Remove unnecessary null-safe calls against Guava multimaps

### DIFF
--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -352,11 +352,11 @@ class KotlinCodeGenerator(
                         .toMap()
 
                 fileSpecsByNamespace.map { (ns, fileSpec) ->
-                    typedefsByNamespace[ns]?.forEach { fileSpec.addTypeAlias(it) }
-                    constantsByNamespace[ns]?.forEach { fileSpec.addProperty(it) }
+                    typedefsByNamespace[ns].forEach { fileSpec.addTypeAlias(it) }
+                    constantsByNamespace[ns].forEach { fileSpec.addProperty(it) }
                     specsByNamespace[ns]
-                            ?.mapNotNull { processor.process(it) }
-                            ?.forEach { fileSpec.addType(it) }
+                            .mapNotNull { processor.process(it) }
+                            .forEach { fileSpec.addType(it) }
                     fileSpec.build()
                 }
             }


### PR DESCRIPTION
As of version 30 or 31, multimaps are now specified to (and annotated as) not return null from `.get(K key)`, even when no values exist for the key.  An empty collection is returned in that case.

This may or may not have been true in the past; I think it was, but there definitely weren't any non-null annotations to tell Kotlin about this fact.  That's fixed, so now we don't need to guard calls with the safe-call operator.