### PR TITLE
Avoid Project#afterEvaluate, add sources on JavaBasePlugin application instead

### DIFF
--- a/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/ThriftyGradlePlugin.java
+++ b/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/ThriftyGradlePlugin.java
@@ -26,9 +26,9 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.Directory;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
 
@@ -66,13 +66,13 @@ public abstract class ThriftyGradlePlugin implements Plugin<Project> {
             t.source(ext.getSources().map(ss -> ss.stream().map(it -> it.getSourceDirectorySet()).collect(Collectors.toList())));
         });
 
-        project.afterEvaluate(p -> {
-            SourceSetContainer sourceSetContainer = (SourceSetContainer) p.property("sourceSets");
-            if (sourceSetContainer == null) {
-                throw new IllegalStateException("expected project property 'sourceSets' not to be null");
-            }
-            SourceSet main = sourceSetContainer.getByName("main");
-            main.getJava().srcDir(thriftTaskProvider);
+        project.getPlugins().withType(JavaBasePlugin.class).configureEach(plugin -> {
+            JavaPluginExtension extension = project.getExtensions().getByType(JavaPluginExtension.class);
+            extension.getSourceSets().configureEach(ss -> {
+                if (ss.getName().equals("main")) {
+                    ss.getJava().srcDir(thriftTaskProvider);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
We were using `afterEvaluate` to paper over some plugin-ordering issues, but that's not very reliable - other plugins can _also_ use `afterEvaluate` and muck with whatever order we were attempting to enforce.

Since this code was written I've learned how to react to plugins as they are added, and more specifically that the source sets we care about are defined by the `JavaBasePlugin`.  So, a safer (and more efficient) way to register generated thrift code is to grab the SourceSet we care about directly from the `JavaPluginExtension` registered by that plugin, as soon as it is added and available.