### PR TITLE
Support omit and emit of field default values in struct constants

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
+++ b/thrifty-java-codegen/src/main/kotlin/com/microsoft.thrifty.gen/ThriftyCodeGenerator.kt
@@ -961,6 +961,8 @@ class ThriftyCodeGenerator {
                             constant.type.trueType,
                             cve,
                             needsDeclaration = false)
+
+                        hasStaticInit.set(true)
                     }
                 }
 

--- a/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
+++ b/thrifty-java-codegen/src/test/kotlin/com/microsoft/thrifty/gen/ThriftyCodeGeneratorTest.kt
@@ -606,6 +606,30 @@ class ThriftyCodeGeneratorTest {
         java shouldContain "public Builder(@NonNull Foo struct)"
     }
 
+    @Test
+    fun structConstWithDefaultValueInField() {
+        val thrift = """
+            |namespace java test.struct_const.default_fields
+            |
+            |struct Foo {
+            |  1: required string text = "FOO";
+            |  2: required i32 number;
+            |}
+            |
+            |const Foo THE_FOO = {"number": 42}
+        """.trimMargin()
+
+        val file = compile("consts.thrift", thrift).single { it.typeSpec.name == "Constants" }
+
+        file.toString() shouldContain """
+            |  static {
+            |    Foo.Builder fooBuilder0 = new Foo.Builder();
+            |    fooBuilder0.number(42);
+            |    THE_FOO = fooBuilder0.build();
+            |  }
+        """.trimMargin()
+    }
+
     private fun compile(filename: String, text: String): List<JavaFile> {
         val schema = parse(filename, text)
         val gen = ThriftyCodeGenerator(schema).emitFileComment(false)

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -1888,14 +1888,13 @@ class KotlinCodeGenerator(
                         block.add("%T(\n⇥", className)
 
                         for (field in structType.fields) {
-                            val fieldValue = fieldValues[field.name]
+                            val fieldValue = fieldValues[field.name] ?: field.defaultValue
                             if (fieldValue != null) {
                                 block.add("%L = ", names[field])
                                 recursivelyRenderConstValue(block, field.type, fieldValue)
                                 block.add(",\n")
                             } else {
                                 check(!field.required) { "Missing value for required field '${field.name}'" }
-                                // TODO: if there's a default value, support it
                                 block.add("%L = null,\n", names[field])
                             }
                         }
@@ -1908,7 +1907,9 @@ class KotlinCodeGenerator(
                         for (field in structType.fields) {
                             val fieldValue = fieldValues[field.name]
                             if (fieldValue == null) {
-                                check(!field.required) { "Missing value for required field '${field.name}'" }
+                                check(!field.required || field.defaultValue != null) {
+                                    "Missing value for required field '${field.name}'"
+                                }
                                 continue
                             }
 

--- a/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -1370,6 +1370,54 @@ class KotlinCodeGeneratorTest {
     }
 
     @Test
+    fun `struct const with default field value using builders`() {
+        val thrift = """
+            |namespace kt test.struct_const.default_fields
+            |
+            |struct Foo {
+            |  1: required string text = "FOO";
+            |  2: required i32 number;
+            |}
+            |
+            |const Foo THE_FOO = {"number": 42}
+        """.trimMargin()
+
+        val file = generate(thrift) { withDataClassBuilders() }
+
+        file.toString() shouldContain """
+            |public val THE_FOO: Foo = Foo.Builder().let {
+            |      it.number(42)
+            |      it.build()
+            |    }
+        """.trimMargin()
+    }
+
+    @Test
+    fun `struct const with default field value using data classes`() {
+        val thrift = """
+            |namespace kt test.struct_const.default_fields
+            |
+            |struct Foo {
+            |  1: required string text = "FOO";
+            |  2: required i32 number;
+            |}
+            |
+            |const Foo THE_FOO = {"number": 42}
+        """.trimMargin()
+
+        val file = generate(thrift)
+
+        println(file)
+
+        file.toString() shouldContain """
+            |public val THE_FOO: Foo = Foo(
+            |      text = "FOO",
+            |      number = 42,
+            |    )
+        """.trimMargin()
+    }
+
+    @Test
     fun `constant reference`() {
         val thrift = """
             |namespace kt test.const_ref

--- a/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
+++ b/thrifty-schema/src/main/kotlin/com/microsoft/thrifty/schema/Constant.kt
@@ -452,8 +452,9 @@ class Constant private constructor (
                     Constant.validate(symbolTable, value, field.type)
                 }
 
-                check(allFields.none { it.value.required }) {
-                    val missingRequiredFieldNames = allFields.filter { it.value.required }.map { it.key }.joinToString(", ")
+                val missingFields = allFields.values.filter { it.required && it.defaultValue == null }
+                check(missingFields.isEmpty()) {
+                    val missingRequiredFieldNames = missingFields.joinToString(", ") { it.name }
                     "Some required fields are unset: $missingRequiredFieldNames"
                 }
             } else {


### PR DESCRIPTION
Java: no change needed in ConstantBuilder; struct builders already include default values
Java: codegen had a bug where we forgot to include a static initializer if _only_ struct constants were present; fixed here.
Kotlin: builder codepath guarded against missing required fields; restriction softened to allow leaving out default-valued fields
Kotlin: builderless codepath now accounts for default values
Schema: Struct validation now allows for missing fields with default values