### PR TITLE
Cache more things in build-src and integration tests

### DIFF
--- a/build-src/gradle.properties
+++ b/build-src/gradle.properties
@@ -1,0 +1,2 @@
+# Build cache is helpful
+org.gradle.caching=true

--- a/build-src/settings.gradle
+++ b/build-src/settings.gradle
@@ -5,3 +5,10 @@ dependencyResolutionManagement {
         }
     }
 }
+
+buildCache {
+    local {
+        directory = new File(rootDir, "../.build-cache")
+        removeUnusedEntriesAfterDays = 30
+    }
+}

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -40,7 +40,11 @@ dependencies {
 
 sourceSets {
     test {
-        java.srcDirs += ['build/generated-src/thrifty/java', 'build/generated-src/thrifty/kotlin']
+        java.srcDirs += [
+                'build/generated-src/thrifty-java/java',
+                'build/generated-src/thrifty-kotlin/kotlin',
+                'build/generated-src/thrifty-kotlin-coro/kotlin'
+        ]
     }
 }
 
@@ -54,12 +58,14 @@ mainClassName = 'com.microsoft.thrifty.compiler.ThriftyCompiler'
 
 def compileTestThrift = tasks.register("compileTestThrift", JavaExec) { t ->
     t.inputs.file("$projectDir/ClientThriftTest.thrift")
-    t.outputs.dir("$projectDir/build/generated-src/thrifty/java")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty-java/java")
+
+    t.outputs.cacheIf("This task is always cacheable based on its inputs") { true }
 
     t.classpath shadowJar.archiveFile
 
     args = [
-            "--out=$projectDir/build/generated-src/thrifty/java",
+            "--out=$projectDir/build/generated-src/thrifty-java/java",
             "--lang=java",
             "$projectDir/ClientThriftTest.thrift"]
 }
@@ -67,12 +73,14 @@ def compileTestThrift = tasks.register("compileTestThrift", JavaExec) { t ->
 
 def kompileTestThrift = tasks.register("kompileTestThrift", JavaExec) { t ->
     t.inputs.file("$projectDir/ClientThriftTest.thrift")
-    t.outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty-kotlin/kotlin")
+
+    t.outputs.cacheIf("This task is always cacheable based on its inputs") { true }
 
     t.classpath shadowJar.archiveFile
 
     args = [
-            "--out=$projectDir/build/generated-src/thrifty/kotlin",
+            "--out=$projectDir/build/generated-src/thrifty-kotlin/kotlin",
             "--kt-struct-builders",
             "--map-type=java.util.LinkedHashMap",
             "--set-type=java.util.LinkedHashSet",
@@ -84,12 +92,14 @@ def kompileTestThrift = tasks.register("kompileTestThrift", JavaExec) { t ->
 
 def kompileCoroutineTestThrift = tasks.register("kompileCoroutineTestThrift", JavaExec) { t ->
     t.inputs.file("$projectDir/CoroutineClientTest.thrift")
-    t.outputs.dir("$projectDir/build/generated-src/thrifty/kotlin")
+    t.outputs.dir("$projectDir/build/generated-src/thrifty-kotlin-coro/kotlin")
+
+    t.outputs.cacheIf("This task is always cacheable based on its inputs") { true }
 
     t.classpath shadowJar.archiveFile
 
     args = [
-            "--out=$projectDir/build/generated-src/thrifty/kotlin",
+            "--out=$projectDir/build/generated-src/thrifty-kotlin-coro/kotlin",
             "--kt-file-per-type",
             "--kt-emit-jvmname",
             "--service-type=coroutine",


### PR DESCRIPTION
JavaExec tasks automatically opt out of caching unless `outputs.cacheIf` is used, so we've ended up always re-generating test thrifts and therefore re-compiling all the integration test code.  Fixed here by using that API, and by making sure that each task writes to a separate directory.

This PR also (hopefully) enables build caching for `build-src`, and uses the same location as the main project, so that we can cache the cache in Github.  It's possible that this was _already_ happening.