### PR TITLE
ISSUE-523 Support comments for struct properties

### DIFF
--- a/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/GenerateThriftSourcesWorkAction.java
+++ b/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/GenerateThriftSourcesWorkAction.java
@@ -177,6 +177,10 @@ public abstract class GenerateThriftSourcesWorkAction implements WorkAction<Gene
             gen.omitServiceClients();
         }
 
+        if (kopt.isStructBuilders()) {
+            gen.withDataClassBuilders();
+        }
+
         if (kopt.isGenerateServer()) {
             gen.generateServer();
         }

--- a/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
+++ b/thrifty-kotlin-codegen/src/main/kotlin/com/microsoft/thrifty/kgen/KotlinCodeGenerator.kt
@@ -553,6 +553,7 @@ class KotlinCodeGenerator(
                     .jvmField()
                     .addAnnotation(thriftField)
 
+            if (field.hasJavadoc) prop.addKdoc("%L", field.documentation)
             if (field.isObfuscated) prop.addAnnotation(Obfuscated::class)
             if (field.isRedacted) prop.addAnnotation(Redacted::class)
 


### PR DESCRIPTION
https://github.com/microsoft/thrifty/issues/523

1) I discovered java generator produces documentation for class and fields by default, so I think it would be better to save same semantic for kotlin generator - so there are no additional flags

2) Fixed issue with ignored `structBuilders` 