### PR TITLE
Refactor code-coverage report into a plugin

### DIFF
--- a/build-src/build.gradle
+++ b/build-src/build.gradle
@@ -32,6 +32,13 @@ gradlePlugin {
             description = "Maven publication logic"
             implementationClass = "com.microsoft.thrifty.ThriftyPublishPlugin"
         }
+
+        coverage {
+            id = "thrifty-coverage-plugin"
+            displayName = "thrifty-coverage-plugin"
+            description = "Jacoco coverage-report logic"
+            implementationClass = "com.microsoft.thrifty.ThriftyCodeCoveragePlugin"
+        }
     }
 }
 

--- a/build-src/src/main/kotlin/com/microsoft/thrifty/ProjectExt.kt
+++ b/build-src/src/main/kotlin/com/microsoft/thrifty/ProjectExt.kt
@@ -20,12 +20,15 @@
  */
 package com.microsoft.thrifty
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 
 val Project.isReleaseBuild: Boolean
     get() {
@@ -46,3 +49,7 @@ inline fun <reified T : Task> TaskCollection<in Task>.withType(): TaskCollection
 inline fun <reified T> ExtensionContainer.findByType(): T? = findByType(T::class.java)
 
 inline fun <reified T : Plugin<Project>> PluginContainer.apply(): T = apply(T::class.java)
+
+inline fun <reified T : Task> TaskContainer.register(name: String, action: Action<in T>): TaskProvider<T> {
+    return register(name, T::class.java, action)
+}

--- a/build-src/src/main/kotlin/com/microsoft/thrifty/ThriftyCodeCoveragePlugin.kt
+++ b/build-src/src/main/kotlin/com/microsoft/thrifty/ThriftyCodeCoveragePlugin.kt
@@ -1,0 +1,65 @@
+package com.microsoft.thrifty
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JvmEcosystemPlugin
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestReport
+import org.gradle.testing.jacoco.tasks.JacocoReport
+import java.io.File
+
+abstract class ThriftyCodeCoveragePlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(Plugins.JACOCO)
+        target.tasks.register<JacocoReport>("codeCoverageReport") {
+            configureReportTask(target, it)
+        }
+    }
+
+    private fun configureReportTask(project: Project, task: JacocoReport) {
+        project.subprojects { sp ->
+            // Multiplatform projects will have an "allTests" task that is not, itself,
+            // a Test subclass - it is a KotlinTestReport.  Jacoco, the way we're using it,
+            // uses what Gradle considers to be output from allTests; if we don't explicitly
+            // declare the dependency, Gradle will fail builds as of version 8.0.
+            task.dependsOn(sp.tasks.withType<Test>())
+            task.dependsOn(sp.tasks.withType<TestReport>().matching { it.name == "allTests" })
+
+            sp.plugins.withType(JvmEcosystemPlugin::class.java).configureEach {
+                sp.extensions
+                    .findByType<SourceSetContainer>()!!
+                    .configureEach {
+                        if (it.name == "main" || it.name.endsWith("Main")) {
+                            task.sourceSets(it)
+                        }
+                    }
+            }
+        }
+
+        val rootPath = project.rootDir.absoluteFile
+        val execData = project.fileTree(rootPath).include("**/build/jacoco/*.exec")
+        task.executionData(execData)
+
+        val filters = listOf(
+            "**/AutoValue_*",
+            "**/antlr/*",
+            "com/microsoft/thrifty/test/gen/*"
+        )
+
+        val filteredClassFiles = project.files(
+            task.classDirectories.files.map {
+                project.fileTree(mapOf("dir" to it, "exclude" to filters))
+            }
+        )
+        task.classDirectories.setFrom(filteredClassFiles)
+
+        val reportFilePath = listOf("reports", "jacoco", "report.xml").joinToString(File.separator)
+        task.reports {
+            it.xml.required.set(true)
+            it.xml.outputLocation.set(project.layout.buildDirectory.file(reportFilePath))
+            it.html.required.set(false)
+            it.csv.required.set(false)
+        }
+    }
+}

--- a/build-src/src/main/kotlin/com/microsoft/thrifty/ThriftyCodeCoveragePlugin.kt
+++ b/build-src/src/main/kotlin/com/microsoft/thrifty/ThriftyCodeCoveragePlugin.kt
@@ -1,3 +1,23 @@
+/*
+ * Thrifty
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,
+ * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
 package com.microsoft.thrifty
 
 import org.gradle.api.Plugin

--- a/build.gradle
+++ b/build.gradle
@@ -21,28 +21,7 @@
 
 plugins {
     id 'thrifty-kotlin-module' apply false
-    id 'jacoco'
-}
-
-tasks.register("codeCoverageReport", JacocoReport) { t ->
-    subprojects.each {
-        t.dependsOn it.tasks.withType(Test)
-        t.dependsOn it.tasks.findAll { it.name == "allTests" } // MPP why are you like this
-        t.sourceSets it.sourceSets.main
-    }
-
-    t.executionData fileTree(project.rootDir.absolutePath).include('**/build/jacoco/*.exec')
-    t.reports {
-        xml.required = true
-        xml.outputLocation = layout.buildDirectory.file("reports/jacoco/report.xml")
-        html.required = true
-        csv.required = false
-    }
-
-    def filters = [ "**/AutoValue_*", "**/antlr/*", "com/microsoft/thrifty/test/gen/*"]
-    t.classDirectories.setFrom(files(t.classDirectories.files.collect {
-        fileTree(dir: it, exclude: filters)
-    }))
+    id 'thrifty-coverage-plugin'
 }
 
 wrapper {


### PR DESCRIPTION
While adding MPP-specific source-sets to the coverage report, it became clear that the coverage report was getting quite complex, and that Groovy was limiting my confidence in correctness.  Refactoring this task into a build-src plugin increases that confidence, just a bit.