### PR TITLE
Pass name style policy to kotlin code generator

### DIFF
--- a/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/GenerateThriftSourcesWorkAction.java
+++ b/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/GenerateThriftSourcesWorkAction.java
@@ -144,7 +144,7 @@ public abstract class GenerateThriftSourcesWorkAction implements WorkAction<Gene
     }
 
     private void generateKotlinThrifts(Schema schema, SerializableThriftOptions opts) throws IOException {
-        KotlinCodeGenerator gen = new KotlinCodeGenerator()
+        KotlinCodeGenerator gen = new KotlinCodeGenerator(policyFromNameStyle(opts.getNameStyle()))
                 .emitJvmName()
                 .filePerType()
                 .failOnUnknownEnumValues(!opts.isAllowUnknownEnumValues());


### PR DESCRIPTION
This fix should make it so that the kotlin code generation respects the `nameStyle` option when using the gradle plugin.

Fixes #537