### PR TITLE
Bump Kotlin, Gradle, fix deprecations

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jvm-version: [8, 17]
+        jvm-version: [17]
         os: [ubuntu-latest, windows-latest]
     env:
       JDK_VERSION: ${{ matrix.jvm-version }}

--- a/build-src/src/main/kotlin/com/microsoft/thrifty/Plugins.kt
+++ b/build-src/src/main/kotlin/com/microsoft/thrifty/Plugins.kt
@@ -22,6 +22,7 @@ package com.microsoft.thrifty
 
 object Plugins {
     const val JAVA = "java-library"
+    const val TEST_SUITE = "jvm-test-suite"
     const val IDEA = "idea"
     const val JACOCO = "jacoco"
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,6 @@ tasks.register("codeCoverageReport", JacocoReport) { t ->
 }
 
 wrapper {
-    gradleVersion = "8.0"
+    gradleVersion = "8.3"
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-junit = "5.8.2"
+junit = "5.10.0"
 kotest = "5.5.4"
-kotlin = "1.8.10"
+kotlin = "1.9.10"
 okio = "3.3.0"
 
 [libraries]
@@ -17,7 +17,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlin-stdlibCommon = { module = "org.jetbrains.kotlin:kotlin-stdlib-common", version.ref = "kotlin" }
 kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
 kotlinPoet = "com.squareup:kotlinpoet:1.12.0"
-mavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.22.0"
+mavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.3"
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
@@ -38,8 +38,7 @@ testing = ["junit", "hamcrest", "kotest-assertions-core", "kotest-assertions-cor
 
 [plugins]
 dokka = "org.jetbrains.dokka:1.7.20"
-gradlePluginPublish = "com.gradle.plugin-publish:0.21.0"
+gradlePluginPublish = "com.gradle.plugin-publish:1.2.1"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-mpp = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-mavenPublish = "com.vanniktech.maven.publish:0.22.0"
-shadow = "com.github.johnrengelman.shadow:7.1.2"
+shadow = "com.github.johnrengelman.shadow:8.1.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/thrifty-gradle-plugin/build.gradle
+++ b/thrifty-gradle-plugin/build.gradle
@@ -27,19 +27,17 @@ plugins {
     alias libs.plugins.gradlePluginPublish
 }
 
-pluginBundle {
+gradlePlugin {
     website = 'https://github.com/microsoft/thrifty'
     vcsUrl = 'https://github.com/microsoft/thrifty.git'
-    tags = ['thrift', 'code-generation', 'thrifty']
-}
 
-gradlePlugin {
     plugins {
         thriftyPlugin {
             id = 'com.microsoft.thrifty'
             displayName = 'Thrifty Gradle Plugin'
             description = 'Generates Java and/or Kotlin sources from .thrift files'
             implementationClass = 'com.microsoft.thrifty.gradle.ThriftyGradlePlugin'
+            tags.set(['thrift', 'code-generation', 'thrifty'])
         }
     }
 }

--- a/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/FieldNameStyle.java
+++ b/thrifty-gradle-plugin/src/main/java/com/microsoft/thrifty/gradle/FieldNameStyle.java
@@ -24,9 +24,12 @@ package com.microsoft.thrifty.gradle;
  * The name styles supported by Thrifty.
  *
  * <table>
+ *     <caption>Name styles supported by Thrifty.</caption>
  *     <thead>
+ *       <tr>
  *         <th>Name</th>
  *         <th>Description</th>
+*        </tr>
  *     </thead>
  *     <tbody>
  *         <tr>

--- a/thrifty-integration-tests/build.gradle
+++ b/thrifty-integration-tests/build.gradle
@@ -54,7 +54,9 @@ shadowJar {
     }
 }
 
-mainClassName = 'com.microsoft.thrifty.compiler.ThriftyCompiler'
+application {
+    mainClass = 'com.microsoft.thrifty.compiler.ThriftyCompiler'
+}
 
 def compileTestThrift = tasks.register("compileTestThrift", JavaExec) { t ->
     t.inputs.file("$projectDir/ClientThriftTest.thrift")

--- a/thrifty-runtime/src/iosMain/kotlin/com/microsoft/thrifty/internal/-Atomics.kt
+++ b/thrifty-runtime/src/iosMain/kotlin/com/microsoft/thrifty/internal/-Atomics.kt
@@ -23,7 +23,7 @@ package com.microsoft.thrifty.internal
 actual class AtomicBoolean actual constructor(
     initialValue: Boolean
 ) {
-    private val actualAtomicBool = kotlin.native.concurrent.AtomicInt(if (initialValue) 1 else 0)
+    private val actualAtomicBool = kotlin.concurrent.AtomicInt(if (initialValue) 1 else 0)
 
     actual fun get(): Boolean {
         return actualAtomicBool.value == 1
@@ -39,9 +39,9 @@ actual class AtomicBoolean actual constructor(
 actual class AtomicInteger actual constructor(
     initialValue: Int
 ) {
-    private val actualAtomicInt = kotlin.native.concurrent.AtomicInt(initialValue)
+    private val actualAtomicInt = kotlin.concurrent.AtomicInt(initialValue)
 
     actual fun get(): Int = actualAtomicInt.value
 
-    actual fun incrementAndGet(): Int = actualAtomicInt.addAndGet(1)
+    actual fun incrementAndGet(): Int = actualAtomicInt.incrementAndGet()
 }

--- a/thrifty-schema/build.gradle
+++ b/thrifty-schema/build.gradle
@@ -53,6 +53,6 @@ tasks.named('compileTestKotlin').configure {
 
 // antlr doesn't hook up nicely with javaSourcesJar, so Gradle complains about
 // it unless we manually specify the dependency between the two
-tasks.matching { it.name == 'javaSourcesJar' }.configureEach {
+tasks.matching { it.name == 'javaSourcesJar' || it.name == 'kotlinSourcesJar' }.configureEach {
     dependsOn 'generateGrammarSource'
 }


### PR DESCRIPTION
Gradle evidently just doesn't gaf about dev experience; updating from 8.1 introduces _so many_ deprecation warnings, including requiring that we either migrate to their still-experimental "test suite" plugin, or start adding `testRuntimeOnly "org.junit.jupiter:junit-platform-launcher"` to all of our modules.  pfft.

We are adopting the test suite plugin here.